### PR TITLE
Temporarly added symfony/form component to composer.json to fix broke…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.3.1 - 2019-07-22
+
+### Fixed
+- Fixed fatal error during composer install caused by https://bugs.php.net/bug.php?id=76980 on php `7.2.20`.
+
 ## 1.3.0 - 2019-07-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - [Installation](#installation)
 - [API documentation](#api-documentation)
 - [CLI documentation](#cli-documentation)
-- [DevOps documentation](#devops-documentation)
+- [DevOps documentation](docs/devops/devops-documentation.md)
 - [Blackfire usage](#blackfire-usage)
 - [Testing](#testing)
 - [Static code analysis with PHPStan](#static-code-analysis-with-phpstan)
@@ -63,10 +63,6 @@ Available commands:
 | `roster:doctrine-result-cache:warmup` | Doctrine result cache warmer | [docs/cli/doctrine-result-cache-warmer-command.md](docs/cli/doctrine-result-cache-warmer-command.md) | 
 | `roster:assignments:bulk-cancel` | Assignment bulk cancellation | [docs/cli/assignment-bulk-cancellation-command.md](docs/cli/assignment-bulk-cancellation-command.md) |
 | `roster:assignments:bulk-create` | Assignment bulk creation | [docs/cli/assignment-bulk-creation-command.md](docs/cli/assignment-bulk-creation-command.md) |
-
-## DevOps documentation
-
-You can find the **DevOps** documentation in [docs/devops/devops-documentation.md](docs/devops/devops-documentation.md)
 
 ## Blackfire usage
 

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         "symfony/console": "^4.0",
         "symfony/dotenv": "^4.2",
         "symfony/flex": "^1.1",
+        "symfony/form": "^4.0",
         "symfony/framework-bundle": "^4.0",
         "symfony/monolog-bundle": "^3.0",
         "symfony/orm-pack": "^1.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,7 +14,7 @@
         <env name="SHELL_VERBOSITY" value="-1"/>
         <env name="KERNEL_CLASS" value="App\Kernel"/>
         <env name="DATABASE_URL" value="sqlite:///%kernel.project_dir%/var/test.db3"/>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=0"/>
     </php>
 
     <testsuites>


### PR DESCRIPTION
There is a fatal error during composer install that prevents simple-roster to get installed properly, caused by the following bug in php 7.2.20:

https://bugs.php.net/bug.php?id=76980
https://github.com/symfony/symfony/issues/32395

A ticket has been created to revert these changes as soon the bug is fixed in future php versions:

https://oat-sa.atlassian.net/browse/TAO-8800