### PR TITLE
Removing Argon2 password encoder

### DIFF
--- a/.env
+++ b/.env
@@ -6,6 +6,10 @@ APP_API_KEY=958f90547ca47a539a731684ec7f9094b36bfe4a
 APP_ROUTE_PREFIX=/api/v1
 ###< symfony/framework-bundle ###
 
+###> symfony/phpunit-bridge ###
+SYMFONY_DEPRECATIONS_HELPER=disabled=1
+###> symfony/phpunit-bridge ###
+
 ###> aws ###
 AWS_REGION=eu-west-1
 AWS_VERSION=latest

--- a/.env
+++ b/.env
@@ -6,10 +6,6 @@ APP_API_KEY=958f90547ca47a539a731684ec7f9094b36bfe4a
 APP_ROUTE_PREFIX=/api/v1
 ###< symfony/framework-bundle ###
 
-###> symfony/phpunit-bridge ###
-SYMFONY_DEPRECATIONS_HELPER=disabled=1
-###> symfony/phpunit-bridge ###
-
 ###> aws ###
 AWS_REGION=eu-west-1
 AWS_VERSION=latest

--- a/.env.test
+++ b/.env.test
@@ -1,7 +1,7 @@
 # define your env variables for the test env here
 KERNEL_CLASS='App\Kernel'
 APP_SECRET='s$cretf0rt3st'
-SYMFONY_DEPRECATIONS_HELPER=disabled
+SYMFONY_DEPRECATIONS_HELPER=max[direct]=10
 LTI_LAUNCH_PRESENTATION_RETURN_URL='http://example.com/index.html'
 APP_ROUTE_PREFIX=/api/v1
 APP_ENV=test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Changelog
 
-## 1.4.2 - 2019-09-18
+## 1.5.0 - TODO: To be released
+
+## Changed
+- Changed password encoding algorithm from hardcoded Argon2i to [automatic](https://symfony.com/blog/new-in-symfony-4-3-native-password-encoder).
+- Increased time cost of password encoding from `1` to `3` following [password hashing guidelines](https://libsodium.gitbook.io/doc/password_hashing/the_argon2i_function#guidelines-for-choosing-the-parameters).
+- Changed test suite bootstrapping mechanism to automatically clear cache before executing the test suite.
 
 ## Fixed
 - Reverted temporary PHPUnit fix done in version `1.4.1`.
 - Reverted temporary fix caused by a PHP `7.2.20` bug done in version `1.4.0`.
+- Moved Symfony deprecation helper from PHPUnit XML configuration file to `.env` file and updated threshold to not break tests by default. 
 
 ## 1.4.1 - 2019-08-08
 

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -1,10 +1,9 @@
 security:
     encoders:
         App\Entity\User:
-            algorithm: argon2i
+            algorithm: auto
             memory_cost: 1024
-            time_cost: 1
-            threads: 1
+            time_cost: 3
 
     providers:
         app_user_provider:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,7 +5,7 @@
          xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
-         bootstrap="config/bootstrap.php"
+         bootstrap="tests/bootstrap.php"
 >
     <php>
         <ini name="error_reporting" value="-1"/>
@@ -14,7 +14,7 @@
         <env name="SHELL_VERBOSITY" value="-1"/>
         <env name="KERNEL_CLASS" value="App\Kernel"/>
         <env name="DATABASE_URL" value="sqlite:///%kernel.project_dir%/var/test.db3"/>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[total]=0"/>
+        <env name="BOOTSTRAP_CLEAR_CACHE_ENV" value="test"/>
     </php>
 
     <testsuites>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; under version 2
+ *  of the License (non-upgradable).
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  Copyright (c) 2019 (original work) Open Assessment Technologies S.A.
+ */
+
+if (isset($_ENV['BOOTSTRAP_CLEAR_CACHE_ENV'])) {
+    passthru(sprintf(
+        'APP_ENV=%s php "%s/../bin/console" cache:clear --no-warmup',
+        $_ENV['BOOTSTRAP_CLEAR_CACHE_ENV'],
+        __DIR__
+    ));
+}
+
+require __DIR__ . '/../config/bootstrap.php';


### PR DESCRIPTION
## Changed
- Changed password encoding algorithm from hardcoded Argon2i to [automatic](https://symfony.com/blog/new-in-symfony-4-3-native-password-encoder).
- Increased time cost of password encoding from `1` to `3` following [password hashing guidelines](https://libsodium.gitbook.io/doc/password_hashing/the_argon2i_function#guidelines-for-choosing-the-parameters).
- Changed test suite bootstrapping mechanism to automatically clear cache before executing the test suite.

## Fixed
- Moved Symfony deprecation helper from PHPUnit XML configuration file to `.env` file and updated threshold to not break tests by default. 
