### PR TITLE
chore: fix php-fpm container

### DIFF
--- a/docker/phpfpm/Dockerfile
+++ b/docker/phpfpm/Dockerfile
@@ -3,12 +3,12 @@ FROM php:7.2-fpm
 ENV SYMFONY_DEPRECATIONS_HELPER=disabled
 
 RUN apt-get update && \
-    apt-get install -y libpng-dev libjpeg-dev libpq-dev zip unzip sudo wget sqlite3 libsqlite3-dev libsodium-dev zlib1g-dev libicu-dev g++ && \
+    apt-get install -y libpng-dev libjpeg-dev libpq-dev zip unzip sudo wget sqlite3 libzstd-dev libsqlite3-dev libsodium-dev zlib1g-dev libicu-dev g++ && \
     rm -rf /var/lib/apt/lists/*
 
 RUN docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr
 RUN docker-php-ext-configure pdo_mysql --with-pdo-mysql=mysqlnd
-RUN docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql
+RUN docker-php-ext-configure pgsql --with-pgsql=/usr/local/pgsql
 RUN docker-php-ext-configure mysqli --with-mysqli=mysqlnd
 
 RUN yes | pecl install igbinary redis apcu xdebug


### PR DESCRIPTION
docker-compose up has been running on error. 2 errors has been identified and fixed in the php-fpm image:
- missing libzstd package (required by redis PECL extension)
- syntax error in pgsql extension config