### PR TITLE
Feature/tdp 57 add max attempts to line items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## 1.5.0 - TODO: To be released
+## 1.6.0 - To be released
+
+### Added
+- Added new property `maxAttempts` to the `LineItem` entity.
+- Added support for ingestion of `maxAttempts` on the `LineItemIngester`.
+
+## 1.5.0 - 2020-06-17
 
 ### Added
 - Added dedicated `docker` application environment for development purposes.

--- a/config/doctrine/LineItem.orm.xml
+++ b/config/doctrine/LineItem.orm.xml
@@ -18,6 +18,10 @@
                 <join-column name="infrastructure_id" referenced-column-name="id"/>
             </join-columns>
         </many-to-one>
-        <field name="maxAttempts" type="integer" column="max_attempts" precision="0" scale="0" nullable="true"/>
+        <field name="maxAttempts" type="integer" column="max_attempts" precision="0" scale="0" nullable="true">
+            <options>
+                <option name="default">0</option>
+            </options>
+        </field>
     </entity>
 </doctrine-mapping>

--- a/config/doctrine/LineItem.orm.xml
+++ b/config/doctrine/LineItem.orm.xml
@@ -18,5 +18,6 @@
                 <join-column name="infrastructure_id" referenced-column-name="id"/>
             </join-columns>
         </many-to-one>
+        <field name="maxAttempts" type="integer" column="max_attempts" precision="0" scale="0" nullable="true"/>
     </entity>
 </doctrine-mapping>

--- a/config/packages/doctrine_migrations.yaml
+++ b/config/packages/doctrine_migrations.yaml
@@ -1,5 +1,3 @@
 doctrine_migrations:
-    dir_name: '%kernel.project_dir%/src/Migrations'
-    # namespace is arbitrary but should be different from App\Migrations
-    # as migrations classes should NOT be autoloaded
-    namespace: DoctrineMigrations
+    migrations_paths:
+        'DoctrineMigrations': '%kernel.project_dir%/src/Migrations'

--- a/config/packages/doctrine_migrations.yaml
+++ b/config/packages/doctrine_migrations.yaml
@@ -1,3 +1,5 @@
 doctrine_migrations:
-    migrations_paths:
-        'DoctrineMigrations': '%kernel.project_dir%/src/Migrations'
+    dir_name: '%kernel.project_dir%/src/Migrations'
+    # namespace is arbitrary but should be different from App\Migrations
+    # as migrations classes should NOT be autoloaded
+    namespace: DoctrineMigrations

--- a/openapi/api_v1.yml
+++ b/openapi/api_v1.yml
@@ -288,6 +288,10 @@ components:
           type: integer
           description: The infrastructure ID
           example: 1
+        maxAttempts:
+          type: integer
+          description: The maximum number of attempts
+          example: 1
     BulkCreateOperation:
       type: object
       properties:

--- a/src/Entity/LineItem.php
+++ b/src/Entity/LineItem.php
@@ -48,6 +48,9 @@ class LineItem implements JsonSerializable, EntityInterface
     /** @var Infrastructure */
     private $infrastructure;
 
+    /** @var int */
+    private $maxAttempts;
+
     public function getId(): ?int
     {
         return $this->id;
@@ -134,6 +137,18 @@ class LineItem implements JsonSerializable, EntityInterface
         return $this->startAt <= $date && $this->endAt >= $date;
     }
 
+    public function getMaxAttempts(): int
+    {
+        return $this->maxAttempts;
+    }
+
+    public function setMaxAttempts(int $maxAttempts): self
+    {
+        $this->maxAttempts = $maxAttempts;
+
+        return $this;
+    }
+
     public function jsonSerialize(): array
     {
         return [
@@ -142,6 +157,7 @@ class LineItem implements JsonSerializable, EntityInterface
             'startDateTime' => $this->getStartAt() !== null ? $this->getStartAt()->getTimestamp() : '',
             'endDateTime' => $this->getEndAt() !== null ? $this->getEndAt()->getTimestamp() : '',
             'infrastructure' => $this->getInfrastructure()->getId(),
+            'maxAttempts' => $this->getMaxAttempts(),
         ];
     }
 }

--- a/src/Entity/LineItem.php
+++ b/src/Entity/LineItem.php
@@ -49,7 +49,7 @@ class LineItem implements JsonSerializable, EntityInterface
     private $infrastructure;
 
     /** @var int */
-    private $maxAttempts;
+    private $maxAttempts = 0;
 
     public function getId(): ?int
     {
@@ -137,7 +137,7 @@ class LineItem implements JsonSerializable, EntityInterface
         return $this->startAt <= $date && $this->endAt >= $date;
     }
 
-    public function getMaxAttempts(): ?int
+    public function getMaxAttempts(): int
     {
         return $this->maxAttempts;
     }

--- a/src/Entity/LineItem.php
+++ b/src/Entity/LineItem.php
@@ -137,7 +137,7 @@ class LineItem implements JsonSerializable, EntityInterface
         return $this->startAt <= $date && $this->endAt >= $date;
     }
 
-    public function getMaxAttempts(): int
+    public function getMaxAttempts(): ?int
     {
         return $this->maxAttempts;
     }

--- a/src/Ingester/Ingester/LineItemIngester.php
+++ b/src/Ingester/Ingester/LineItemIngester.php
@@ -68,6 +68,7 @@ class LineItemIngester extends AbstractIngester
             ->setUri($data['uri'])
             ->setLabel($data['label'])
             ->setSlug($data['slug'])
+            ->setMaxAttempts((int)$data['maxAttempts'])
             ->setInfrastructure($this->infrastructureCollection[$data['infrastructure']]);
 
         if (isset($data['startTimestamp']) && $data['endTimestamp']) {

--- a/tests/Fixtures/100usersWithAssignments.yml
+++ b/tests/Fixtures/100usersWithAssignments.yml
@@ -13,6 +13,7 @@ App\Entity\LineItem:
     slug: 'lineItemSlug'
     startAt: '<dateTimeInInterval("-2 years", "-1 years")>'
     endAt: '<dateTimeInInterval("+1 years", "+2 years")>'
+    maxAttempts: 1
   lineItem2:
     infrastructure: '@infrastructure'
     label: 'The second line item'
@@ -20,6 +21,7 @@ App\Entity\LineItem:
     slug: 'lineItemSlug2'
     startAt: '<dateTimeInInterval("-2 years", "-1 years")>'
     endAt: '<dateTimeInInterval("+1 years", "+2 years")>'
+    maxAttempts: 1
   lineItem3:
     infrastructure: '@infrastructure'
     label: 'The third line item'
@@ -27,6 +29,7 @@ App\Entity\LineItem:
     slug: 'lineItemSlug3'
     startAt: '<dateTimeInInterval("-2 years", "-1 years")>'
     endAt: '<dateTimeInInterval("+1 years", "+2 years")>'
+    maxAttempts: 1
 
 App\Entity\Assignment:
   assignment_{1..50}:

--- a/tests/Fixtures/userWithReadyAssignment.yml
+++ b/tests/Fixtures/userWithReadyAssignment.yml
@@ -13,6 +13,7 @@ App\Entity\LineItem:
         slug: 'lineItemSlug'
         startAt: '<dateTimeInInterval("-2 years", "-1 years")>'
         endAt: '<dateTimeInInterval("+1 years", "+2 years")>'
+        maxAttempts: 1
 
 App\Entity\User:
     user1:

--- a/tests/Fixtures/usersWithStartedButStuckAssignments.yml
+++ b/tests/Fixtures/usersWithStartedButStuckAssignments.yml
@@ -13,6 +13,7 @@ App\Entity\LineItem:
     slug: 'lineItemSlug'
     startAt: '<dateTimeInInterval("-2 years", "-1 years")>'
     endAt: '<dateTimeInInterval("+1 years", "+2 years")>'
+    maxAttempts: 1
 
 App\Entity\Assignment:
   startedButStuckAssignment_{1..10}:

--- a/tests/Functional/Action/Assignment/ListUserAssignmentsActionTest.php
+++ b/tests/Functional/Action/Assignment/ListUserAssignmentsActionTest.php
@@ -91,6 +91,7 @@ class ListUserAssignmentsActionTest extends WebTestCase
                         'startDateTime' => $lineItem->getStartAt()->getTimestamp(),
                         'endDateTime' => $lineItem->getEndAt()->getTimestamp(),
                         'infrastructure' => $lineItem->getInfrastructure()->getId(),
+                        'maxAttempts' => $lineItem->getMaxAttempts(),
                     ],
                 ],
             ],

--- a/tests/Integration/Ingester/Ingester/LineItemIngesterTest.php
+++ b/tests/Integration/Ingester/Ingester/LineItemIngesterTest.php
@@ -104,7 +104,8 @@ class LineItemIngesterTest extends KernelTestCase
                 'slug' => 'gra13_ita_1',
                 'infrastructure' => 'infra_2',
                 'startTimestamp' => '1546682400',
-                'endTimestamp' => '1546713000'
+                'endTimestamp' => '1546713000',
+                'maxAttempts' => 0,
             ],
             $failure->getData()
         );

--- a/tests/Integration/Ingester/Ingester/LineItemIngesterTest.php
+++ b/tests/Integration/Ingester/Ingester/LineItemIngesterTest.php
@@ -130,9 +130,11 @@ class LineItemIngesterTest extends KernelTestCase
 
         $lineItem1 = $this->getRepository(LineItem::class)->find(1);
         $this->assertEquals('gra13_ita_1', $lineItem1->getSlug());
+        $this->assertEquals(1, $lineItem1->getMaxAttempts());
 
         $lineItem6 = $this->getRepository(LineItem::class)->find(6);
         $this->assertEquals('gra13_ita_6', $lineItem6->getSlug());
+        $this->assertEquals(2, $lineItem6->getMaxAttempts());
     }
 
     private function createIngesterSource(string $path): IngesterSourceInterface

--- a/tests/Resources/Ingester/Invalid/line-items.csv
+++ b/tests/Resources/Ingester/Invalid/line-items.csv
@@ -2,4 +2,4 @@ uri,label,slug,infrastructure,startTimestamp,endTimestamp,maxAttempts
 http://taoplatform.loc/delivery_1.rdf,label1,gra13_ita_1,infra_1,1546682400,1546713000,0
 http://taoplatform.loc/delivery_2.rdf,label2,gra13_ita_1,infra_2,1546682400,1546713000,0
 http://taoplatform.loc/delivery_3.rdf,label3,gra13_ita_1,infra_3,,1546713000,0
-http://taoplatform.loc/delivery_4.rdf,label4,gra13_ita_1,infra_4,1546682400,0,
+http://taoplatform.loc/delivery_4.rdf,label4,gra13_ita_1,infra_4,1546682400,,0

--- a/tests/Resources/Ingester/Invalid/line-items.csv
+++ b/tests/Resources/Ingester/Invalid/line-items.csv
@@ -1,5 +1,5 @@
-uri,label,slug,infrastructure,startTimestamp,endTimestamp
-http://taoplatform.loc/delivery_1.rdf,label1,gra13_ita_1,infra_1,1546682400,1546713000
-http://taoplatform.loc/delivery_2.rdf,label2,gra13_ita_1,infra_2,1546682400,1546713000
-http://taoplatform.loc/delivery_3.rdf,label3,gra13_ita_1,infra_3,,1546713000
-http://taoplatform.loc/delivery_4.rdf,label4,gra13_ita_1,infra_4,1546682400,
+uri,label,slug,infrastructure,startTimestamp,endTimestamp,maxAttempts
+http://taoplatform.loc/delivery_1.rdf,label1,gra13_ita_1,infra_1,1546682400,1546713000,0
+http://taoplatform.loc/delivery_2.rdf,label2,gra13_ita_1,infra_2,1546682400,1546713000,0
+http://taoplatform.loc/delivery_3.rdf,label3,gra13_ita_1,infra_3,,1546713000,0
+http://taoplatform.loc/delivery_4.rdf,label4,gra13_ita_1,infra_4,1546682400,0,

--- a/tests/Resources/Ingester/Valid/line-items.csv
+++ b/tests/Resources/Ingester/Valid/line-items.csv
@@ -1,7 +1,7 @@
 uri,label,slug,infrastructure,startTimestamp,endTimestamp,maxAttempts
-http://taoplatform.loc/delivery_1.rdf,label1,gra13_ita_1,infra_1,1546682400,1546713000,0
-http://taoplatform.loc/delivery_2.rdf,label2,gra13_ita_2,infra_2,1546682400,1546713000,0
-http://taoplatform.loc/delivery_3.rdf,label2,gra13_ita_3,infra_3,1546682400,1546713000,0
-http://taoplatform.loc/delivery_4.rdf,label4,gra13_ita_4,infra_1,1546682400,1546713000,0
-http://taoplatform.loc/delivery_5.rdf,label5,gra13_ita_5,infra_2,1546682400,1546713000,0
-http://taoplatform.loc/delivery_6.rdf,label6,gra13_ita_6,infra_3,1546682400,1546713000,0
+http://taoplatform.loc/delivery_1.rdf,label1,gra13_ita_1,infra_1,1546682400,1546713000,1
+http://taoplatform.loc/delivery_2.rdf,label2,gra13_ita_2,infra_2,1546682400,1546713000,2
+http://taoplatform.loc/delivery_3.rdf,label2,gra13_ita_3,infra_3,1546682400,1546713000,1
+http://taoplatform.loc/delivery_4.rdf,label4,gra13_ita_4,infra_1,1546682400,1546713000,2
+http://taoplatform.loc/delivery_5.rdf,label5,gra13_ita_5,infra_2,1546682400,1546713000,1
+http://taoplatform.loc/delivery_6.rdf,label6,gra13_ita_6,infra_3,1546682400,1546713000,2

--- a/tests/Resources/Ingester/Valid/line-items.csv
+++ b/tests/Resources/Ingester/Valid/line-items.csv
@@ -1,7 +1,7 @@
-uri,label,slug,infrastructure,startTimestamp,endTimestamp
-http://taoplatform.loc/delivery_1.rdf,label1,gra13_ita_1,infra_1,1546682400,1546713000
-http://taoplatform.loc/delivery_2.rdf,label2,gra13_ita_2,infra_2,1546682400,1546713000
-http://taoplatform.loc/delivery_3.rdf,label2,gra13_ita_3,infra_3,1546682400,1546713000
-http://taoplatform.loc/delivery_4.rdf,label4,gra13_ita_4,infra_1,1546682400,1546713000
-http://taoplatform.loc/delivery_5.rdf,label5,gra13_ita_5,infra_2,1546682400,1546713000
-http://taoplatform.loc/delivery_6.rdf,label6,gra13_ita_6,infra_3,1546682400,1546713000
+uri,label,slug,infrastructure,startTimestamp,endTimestamp,maxAttempts
+http://taoplatform.loc/delivery_1.rdf,label1,gra13_ita_1,infra_1,1546682400,1546713000,0
+http://taoplatform.loc/delivery_2.rdf,label2,gra13_ita_2,infra_2,1546682400,1546713000,0
+http://taoplatform.loc/delivery_3.rdf,label2,gra13_ita_3,infra_3,1546682400,1546713000,0
+http://taoplatform.loc/delivery_4.rdf,label4,gra13_ita_4,infra_1,1546682400,1546713000,0
+http://taoplatform.loc/delivery_5.rdf,label5,gra13_ita_5,infra_2,1546682400,1546713000,0
+http://taoplatform.loc/delivery_6.rdf,label6,gra13_ita_6,infra_3,1546682400,1546713000,0


### PR DESCRIPTION
Ticket : https://oat-sa.atlassian.net/browse/TDP-57

_This pull request adds a new property maxAttempts to the LineItem entity in order to be able to have multiple assignments per user for a single line item._

* Added a new maxAttempts (int) to the LineItem entity & its normalized version
* Fixed the LineItemIngested to handle the new maxAttempts property
* Fixed Open API
* Fixed fixtures
* Fixed tests

✔️ All tests run with 100% coverage
✔️ PHPStan runs with level _max_
✔️ Infection runs successfully with multiple threads (99%)