### PR TITLE
Feature/tdp 58 add attempt to assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
 ### Added
 - Added new property `maxAttempts` to the `LineItem` entity.
 - Added support for ingestion of `maxAttempts` on the `LineItemIngester`.
+- Added new property `attemptsCount` to the `Assignment` entity.
+
+### Changed
+- Changed LTI outcome state update to `ready` if `Assignment` has additional attempts available.
+- Changed garbage collection state update to `ready` if `Assignment` has additional attempts available.
+- Increment the `attemptsCount` on upon LTI Launch.
+- Set default value of `0` for `attemptsCount` for new assignments during user ingestion.
 
 ## 1.5.0 - 2020-06-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 ### Changed
 - Changed LTI outcome state update to `ready` if `Assignment` has additional attempts available.
 - Changed garbage collection state update to `ready` if `Assignment` has additional attempts available.
-- Increment the `attemptsCount` on upon LTI Launch.
+- Increment the `attemptsCount` on upon LTI Launch if state is not started.
 - Set default value of `0` for `attemptsCount` for new assignments during user ingestion.
 
 ## 1.5.0 - 2020-06-17

--- a/config/doctrine/Assignment.orm.xml
+++ b/config/doctrine/Assignment.orm.xml
@@ -9,7 +9,11 @@
         </id>
         <field name="state" type="string" column="state" length="255" precision="0" scale="0" nullable="false"/>
         <field name="updatedAt" type="datetime" column="updated_at" nullable="true"/>
-        <field name="attemptsCount" type="integer" column="attempts_count" precision="0" scale="0" nullable="true"/>
+        <field name="attemptsCount" type="integer" column="attempts_count" precision="0" scale="0" nullable="true">
+            <options>
+                <option name="default">0</option>
+            </options>
+        </field>
         <many-to-one field="user" target-entity="App\Entity\User" inversed-by="assignments" fetch="LAZY">
             <cascade>
                 <cascade-persist/>

--- a/config/doctrine/Assignment.orm.xml
+++ b/config/doctrine/Assignment.orm.xml
@@ -9,6 +9,7 @@
         </id>
         <field name="state" type="string" column="state" length="255" precision="0" scale="0" nullable="false"/>
         <field name="updatedAt" type="datetime" column="updated_at" nullable="true"/>
+        <field name="attemptsCount" type="integer" column="attempts_count" precision="0" scale="0" nullable="true"/>
         <many-to-one field="user" target-entity="App\Entity\User" inversed-by="assignments" fetch="LAZY">
             <cascade>
                 <cascade-persist/>

--- a/openapi/api_v1.yml
+++ b/openapi/api_v1.yml
@@ -264,6 +264,10 @@ components:
             - completed
             - cancelled
           example: started
+        attemptsCount:
+          type: integer
+          description: Number of time this assignment has been attempted.
+          example: 2
         lineItem:
           $ref: '#/components/schemas/LineItem'
     LineItem:

--- a/src/Action/Lti/GetUserAssignmentLtiLinkAction.php
+++ b/src/Action/Lti/GetUserAssignmentLtiLinkAction.php
@@ -70,7 +70,10 @@ class GetUserAssignmentLtiLinkAction
             $assignment = $user->getAvailableAssignmentById($assignmentId);
             $ltiRequest = $this->getUserAssignmentLtiRequestService->getAssignmentLtiRequest($assignment);
 
-            $assignment->setState(Assignment::STATE_STARTED);
+            $assignment
+                ->setState(Assignment::STATE_STARTED)
+                ->incrementAttemptsCount();
+
             $this->entityManager->flush();
 
             $this->logger->info(

--- a/src/Action/Lti/GetUserAssignmentLtiLinkAction.php
+++ b/src/Action/Lti/GetUserAssignmentLtiLinkAction.php
@@ -54,7 +54,8 @@ class GetUserAssignmentLtiLinkAction
         GetUserAssignmentLtiRequestService $getUserAssignmentLtiRequestService,
         EntityManagerInterface $entityManager,
         LoggerInterface $logger
-    ) {
+    )
+    {
         $this->responder = $responder;
         $this->getUserAssignmentLtiRequestService = $getUserAssignmentLtiRequestService;
         $this->entityManager = $entityManager;
@@ -70,9 +71,11 @@ class GetUserAssignmentLtiLinkAction
             $assignment = $user->getAvailableAssignmentById($assignmentId);
             $ltiRequest = $this->getUserAssignmentLtiRequestService->getAssignmentLtiRequest($assignment);
 
-            $assignment
-                ->setState(Assignment::STATE_STARTED)
-                ->incrementAttemptsCount();
+            if ($assignment->getState() !== Assignment::STATE_STARTED) {
+                $assignment
+                    ->setState(Assignment::STATE_STARTED)
+                    ->incrementAttemptsCount();
+            }
 
             $this->entityManager->flush();
 

--- a/src/Command/GarbageCollector/AssignmentGarbageCollectorCommand.php
+++ b/src/Command/GarbageCollector/AssignmentGarbageCollectorCommand.php
@@ -58,7 +58,8 @@ class AssignmentGarbageCollectorCommand extends Command
         AssignmentRepository $assignmentRepository,
         LoggerInterface $logger,
         string $cleanUpInterval
-    ) {
+    )
+    {
         parent::__construct(self::NAME);
 
         $this->assignmentRepository = $assignmentRepository;
@@ -141,7 +142,8 @@ class AssignmentGarbageCollectorCommand extends Command
             /** @var Assignment $assignment */
             $assignmentCount = $stuckAssignments->getIterator()->count();
             foreach ($stuckAssignments as $assignment) {
-                $assignment->setState(Assignment::STATE_COMPLETED);
+                $assignment->complete();
+
                 if (!$isDryRun) {
                     $this->assignmentRepository->persist($assignment);
                 }

--- a/src/Command/GarbageCollector/AssignmentGarbageCollectorCommand.php
+++ b/src/Command/GarbageCollector/AssignmentGarbageCollectorCommand.php
@@ -58,8 +58,7 @@ class AssignmentGarbageCollectorCommand extends Command
         AssignmentRepository $assignmentRepository,
         LoggerInterface $logger,
         string $cleanUpInterval
-    )
-    {
+    ) {
         parent::__construct(self::NAME);
 
         $this->assignmentRepository = $assignmentRepository;

--- a/src/Command/GarbageCollector/AssignmentGarbageCollectorCommand.php
+++ b/src/Command/GarbageCollector/AssignmentGarbageCollectorCommand.php
@@ -109,9 +109,8 @@ class AssignmentGarbageCollectorCommand extends Command
 
             $successMessage = $numberOfCollectedAssignments !== 0
                 ? sprintf(
-                    "Total of '%s' stuck assignments were successfully marked as '%s'.",
-                    $numberOfCollectedAssignments,
-                    Assignment::STATE_COMPLETED
+                    "Total of '%s' stuck assignments were successfully collected.",
+                    $numberOfCollectedAssignments
                 )
                 : 'Nothing to update.';
 
@@ -151,9 +150,10 @@ class AssignmentGarbageCollectorCommand extends Command
                 $numberOfCollectedAssignments++;
                 $this->logger->info(
                     sprintf(
-                        "Assignment with id='%s' of user with username='%s' has been marked as completed by garbage collector.",
+                        "Assignment with id='%s' of user with username='%s' has been collected and marked as '%s' by garbage collector.",
                         $assignment->getId(),
-                        $assignment->getUser()->getUsername()
+                        $assignment->getUser()->getUsername(),
+                        $assignment->getState()
                     )
                 );
             }

--- a/src/Command/Ingester/Native/NativeUserIngesterCommand.php
+++ b/src/Command/Ingester/Native/NativeUserIngesterCommand.php
@@ -186,11 +186,12 @@ class NativeUserIngesterCommand extends Command
                 );
 
                 $this->assignmentQueryParts[] = sprintf(
-                    "(%s, %s, %s, '%s')",
+                    "(%s, %s, %s, '%s', %d)",
                     $index,
                     $index,
                     $lineItemCollection[$row['slug']]->getId(),
-                    Assignment::STATE_READY
+                    Assignment::STATE_READY,
+                    0
                 );
 
                 if ($index % $this->batchSize === 0) {
@@ -246,7 +247,7 @@ class NativeUserIngesterCommand extends Command
                 $this->entityManager->createNativeQuery($userQuery, $mapping)->execute();
 
                 $assignmentQuery = sprintf(
-                    'INSERT INTO assignments (id, user_id, line_item_id, state) VALUES %s',
+                    'INSERT INTO assignments (id, user_id, line_item_id, state, attempts_count) VALUES %s',
                     implode(',', $this->assignmentQueryParts)
                 );
 

--- a/src/Entity/Assignment.php
+++ b/src/Entity/Assignment.php
@@ -64,6 +64,9 @@ class Assignment implements JsonSerializable, EntityInterface
     /** @var DateTime */
     private $updatedAt;
 
+    /** @var int */
+    private $attemptsCount = 0;
+
     public function getId(): ?int
     {
         return $this->id;
@@ -134,12 +137,45 @@ class Assignment implements JsonSerializable, EntityInterface
         return in_array($this->state, [self::STATE_STARTED, self::STATE_READY], true);
     }
 
+    public function getAttemptsCount(): int
+    {
+        return $this->attemptsCount;
+    }
+
+    public function setAttemptsCount(int $attemptsCount): self
+    {
+        $this->attemptsCount = $attemptsCount;
+
+        return $this;
+    }
+
+    public function incrementAttemptsCount(): self
+    {
+        $this->attemptsCount++;
+
+        return $this;
+    }
+
+    public function complete(): self
+    {
+        $maxAttempts = $this->getLineItem()->getMaxAttempts();
+
+        if ($maxAttempts === 0 || $this->getAttemptsCount() < $maxAttempts) {
+            $this->setState(Assignment::STATE_READY);
+        } else {
+            $this->setState(Assignment::STATE_COMPLETED);
+        }
+
+        return $this;
+    }
+
     public function jsonSerialize(): array
     {
         return [
             'id' => $this->id,
             'username' => $this->getUser()->getUsername(),
             'state' => $this->getState(),
+            'attemptsCount' => $this->getAttemptsCount(),
             'lineItem' => $this->lineItem,
         ];
     }

--- a/src/Ingester/Ingester/UserIngester.php
+++ b/src/Ingester/Ingester/UserIngester.php
@@ -62,7 +62,8 @@ class UserIngester extends AbstractIngester
         $assignment = new Assignment();
         $assignment
             ->setLineItem($this->lineItemCollection[$data['slug']])
-            ->setState(Assignment::STATE_READY);
+            ->setState(Assignment::STATE_READY)
+            ->setAttemptsCount(0);
 
         $user = (new User())
             ->setUsername($data['username'])

--- a/src/Lti/Service/GetUserAssignmentLtiRequestService.php
+++ b/src/Lti/Service/GetUserAssignmentLtiRequestService.php
@@ -130,7 +130,7 @@ class GetUserAssignmentLtiRequestService
             );
         }
 
-        if ($assignment->getAttemptsCount() >= $assignment->getLineItem()->getMaxAttempts()) {
+        if ($assignment->getAttemptsCount() >= $assignment->getLineItem()->getMaxAttempts() && $assignment->getState() !== Assignment::STATE_STARTED) {
             throw new AssignmentNotProcessableException(
                 sprintf("Assignment with id '%s' has reached the maximum attempts.", $assignment->getId())
             );

--- a/src/Lti/Service/GetUserAssignmentLtiRequestService.php
+++ b/src/Lti/Service/GetUserAssignmentLtiRequestService.php
@@ -129,6 +129,12 @@ class GetUserAssignmentLtiRequestService
                 sprintf("Assignment with id '%s' does not have a suitable state.", $assignment->getId())
             );
         }
+
+        if ($assignment->getAttemptsCount() >= $assignment->getLineItem()->getMaxAttempts()) {
+            throw new AssignmentNotProcessableException(
+                sprintf("Assignment with id '%s' has reached the maximum attempts.", $assignment->getId())
+            );
+        }
     }
 
     private function getAssignmentLtiLink(Assignment $assignment): string

--- a/src/Service/CompleteUserAssignmentService.php
+++ b/src/Service/CompleteUserAssignmentService.php
@@ -54,7 +54,7 @@ class CompleteUserAssignmentService
             throw new AssignmentNotFoundException(sprintf("Assignment with id '%s' not found.", $assignmentId));
         }
 
-        $assignment->setState(Assignment::STATE_COMPLETED);
+        $assignment->complete();
 
         $this->assignmentRepository->persist($assignment);
         $this->assignmentRepository->flush();

--- a/tests/Fixtures/userWithReadyAssignment.yml
+++ b/tests/Fixtures/userWithReadyAssignment.yml
@@ -26,3 +26,4 @@ App\Entity\Assignment:
     assignment1:
         lineItem: '@lineItem1'
         state: 'ready'
+        attemptsCount: 1

--- a/tests/Fixtures/userWithReadyAssignment.yml
+++ b/tests/Fixtures/userWithReadyAssignment.yml
@@ -13,7 +13,7 @@ App\Entity\LineItem:
         slug: 'lineItemSlug'
         startAt: '<dateTimeInInterval("-2 years", "-1 years")>'
         endAt: '<dateTimeInInterval("+1 years", "+2 years")>'
-        maxAttempts: 1
+        maxAttempts: 2
 
 App\Entity\User:
     user1:

--- a/tests/Fixtures/usersWithStartedButStuckAssignments.yml
+++ b/tests/Fixtures/usersWithStartedButStuckAssignments.yml
@@ -8,21 +8,40 @@ App\Entity\Infrastructure:
 App\Entity\LineItem:
   lineItem:
     infrastructure: '@infrastructure'
-    label: 'The first line item'
+    label: 'The first line item with single attempt'
     uri: 'http://lineitemuri.com'
     slug: 'lineItemSlug'
     startAt: '<dateTimeInInterval("-2 years", "-1 years")>'
     endAt: '<dateTimeInInterval("+1 years", "+2 years")>'
     maxAttempts: 1
+  lineItem2:
+    infrastructure: '@infrastructure'
+    label: 'The second line item with infinite attempts'
+    uri: 'http://lineitemuri.com'
+    slug: 'lineItem2Slug'
+    startAt: '<dateTimeInInterval("-2 years", "-1 years")>'
+    endAt: '<dateTimeInInterval("+1 years", "+2 years")>'
+    maxAttempts: 0
 
 App\Entity\Assignment:
-  startedButStuckAssignment_{1..10}:
+  startedButStuckAssignment_{1..5}:
     lineItem: '@lineItem'
     state: 'started'
     updatedAt: '<dateTimeInInterval("-5 days", "-4 days")>'
+    attemptsCount: 1
+  startedButStuckAssignment_{6..10}:
+    lineItem: '@lineItem'
+    state: 'started'
+    updatedAt: '<dateTimeInInterval("-5 days", "-4 days")>'
+    attemptsCount: 0
+  startedButStuckAssignment_{11..15}:
+    lineItem: '@lineItem2'
+    state: 'started'
+    updatedAt: '<dateTimeInInterval("-5 days", "-4 days")>'
+    attemptsCount: 1
 
 App\Entity\User:
-  userWithStartedButStuckAssignment_{1..10}:
+  userWithStartedButStuckAssignment_{1..15}:
     username: 'userWithStartedButStuckAssignment_<current()>'
     plainPassword: 'password'
     assignments: ['@startedButStuckAssignment_<current()>']

--- a/tests/Fixtures/usersWithStartedButStuckAssignments.yml
+++ b/tests/Fixtures/usersWithStartedButStuckAssignments.yml
@@ -8,7 +8,7 @@ App\Entity\Infrastructure:
 App\Entity\LineItem:
   lineItem:
     infrastructure: '@infrastructure'
-    label: 'The first line item with single attempt'
+    label: 'The first line item with 1 maximum attempt'
     uri: 'http://lineitemuri.com'
     slug: 'lineItemSlug'
     startAt: '<dateTimeInInterval("-2 years", "-1 years")>'
@@ -24,24 +24,24 @@ App\Entity\LineItem:
     maxAttempts: 0
 
 App\Entity\Assignment:
-  startedButStuckAssignment_{1..5}:
+  startedButStuckAssignment_{1..3}:
     lineItem: '@lineItem'
     state: 'started'
     updatedAt: '<dateTimeInInterval("-5 days", "-4 days")>'
     attemptsCount: 1
-  startedButStuckAssignment_{6..10}:
+  startedButStuckAssignment_{4..7}:
     lineItem: '@lineItem'
     state: 'started'
     updatedAt: '<dateTimeInInterval("-5 days", "-4 days")>'
     attemptsCount: 0
-  startedButStuckAssignment_{11..15}:
+  startedButStuckAssignment_{8..10}:
     lineItem: '@lineItem2'
     state: 'started'
     updatedAt: '<dateTimeInInterval("-5 days", "-4 days")>'
     attemptsCount: 1
 
 App\Entity\User:
-  userWithStartedButStuckAssignment_{1..15}:
+  userWithStartedButStuckAssignment_{1..10}:
     username: 'userWithStartedButStuckAssignment_<current()>'
     plainPassword: 'password'
     assignments: ['@startedButStuckAssignment_<current()>']

--- a/tests/Functional/Action/Assignment/ListUserAssignmentsActionTest.php
+++ b/tests/Functional/Action/Assignment/ListUserAssignmentsActionTest.php
@@ -93,6 +93,7 @@ class ListUserAssignmentsActionTest extends WebTestCase
                         'infrastructure' => $lineItem->getInfrastructure()->getId(),
                         'maxAttempts' => $lineItem->getMaxAttempts(),
                     ],
+                    'attemptsCount' => $user->getLastAssignment()->getAttemptsCount(),
                 ],
             ],
         ], json_decode($this->kernelBrowser->getResponse()->getContent(), true));

--- a/tests/Functional/Action/Lti/UpdateLtiOutcomeActionTest.php
+++ b/tests/Functional/Action/Lti/UpdateLtiOutcomeActionTest.php
@@ -117,7 +117,7 @@ class UpdateLtiOutcomeActionTest extends WebTestCase
         $this->assertEquals(Response::HTTP_OK, $this->kernelBrowser->getResponse()->getStatusCode());
 
         $this->assertEquals(
-            Assignment::STATE_COMPLETED,
+            Assignment::STATE_READY,
             $this->getAssignment()->getState()
         );
     }

--- a/tests/Functional/Command/GarbageCollector/AssignmentGarbageCollectorCommandTest.php
+++ b/tests/Functional/Command/GarbageCollector/AssignmentGarbageCollectorCommandTest.php
@@ -72,12 +72,12 @@ class AssignmentGarbageCollectorCommandTest extends KernelTestCase
 
         $this->assertEquals(0, $this->commandTester->execute([]));
         $this->assertStringContainsString(
-            "[OK] Total of '10' stuck assignments were successfully marked as 'completed'.",
+            "[OK] Total of '15' stuck assignments were successfully collected.",
             $this->commandTester->getDisplay()
         );
 
         $this->assertCount(
-            10,
+            15,
             $this->getRepository(Assignment::class)->findBy(['state' => Assignment::STATE_STARTED])
         );
     }
@@ -93,14 +93,25 @@ class AssignmentGarbageCollectorCommandTest extends KernelTestCase
             ]
         ));
         $this->assertStringContainsString(
-            "[OK] Total of '10' stuck assignments were successfully marked as 'completed'.",
+            "[OK] Total of '15' stuck assignments were successfully collected.",
             $this->commandTester->getDisplay()
         );
 
-        for ($i = 1; $i <= 10; $i++) {
+        for ($i = 1; $i <= 5; $i++) {
             $this->assertHasLogRecordWithMessage(
                 sprintf(
-                    "Assignment with id='%s' of user with username='%s' has been marked as completed by garbage collector.",
+                    "Assignment with id='%s' of user with username='%s' has been collected and marked as 'completed' by garbage collector.",
+                    $i,
+                    'userWithStartedButStuckAssignment_' . $i
+                ),
+                Logger::INFO
+            );
+        }
+
+        for ($i = 6; $i <= 15; $i++) {
+            $this->assertHasLogRecordWithMessage(
+                sprintf(
+                    "Assignment with id='%s' of user with username='%s' has been collected and marked as 'ready' by garbage collector.",
                     $i,
                     'userWithStartedButStuckAssignment_' . $i
                 ),
@@ -110,7 +121,7 @@ class AssignmentGarbageCollectorCommandTest extends KernelTestCase
 
         /** @var Assignment $assignment */
         foreach ($this->getRepository(Assignment::class)->findAll() as $assignment) {
-            $this->assertEquals(Assignment::STATE_COMPLETED, $assignment->getState());
+            $this->assertCollectedAssignmentStateIsCorrect($assignment);
             $this->assertEquals(Carbon::now()->toDateTime(), $assignment->getUpdatedAt());
         }
     }
@@ -129,13 +140,13 @@ class AssignmentGarbageCollectorCommandTest extends KernelTestCase
             )
         );
         $this->assertStringContainsString(
-            "[OK] Total of '10' stuck assignments were successfully marked as 'completed'.",
+            "[OK] Total of '15' stuck assignments were successfully collected.",
             $this->commandTester->getDisplay()
         );
 
         /** @var Assignment $assignment */
         foreach ($this->getRepository(Assignment::class)->findAll() as $assignment) {
-            $this->assertEquals(Assignment::STATE_COMPLETED, $assignment->getState());
+            $this->assertCollectedAssignmentStateIsCorrect($assignment);
             $this->assertEquals(Carbon::now()->toDateTime(), $assignment->getUpdatedAt());
         }
     }
@@ -147,5 +158,14 @@ class AssignmentGarbageCollectorCommandTest extends KernelTestCase
             "[ERROR] Invalid 'batch-size' argument received.",
             $this->commandTester->getDisplay()
         );
+    }
+
+    public function assertCollectedAssignmentStateIsCorrect(Assignment $assignment): void
+    {
+        if ($assignment->getLineItem()->getMaxAttempts() === 0 || $assignment->getAttemptsCount() < $assignment->getLineItem()->getMaxAttempts()) {
+            $this->assertEquals(Assignment::STATE_READY, $assignment->getState());
+        } else {
+            $this->assertEquals(Assignment::STATE_COMPLETED, $assignment->getState());
+        }
     }
 }

--- a/tests/Functional/Command/GarbageCollector/AssignmentGarbageCollectorCommandTest.php
+++ b/tests/Functional/Command/GarbageCollector/AssignmentGarbageCollectorCommandTest.php
@@ -72,12 +72,12 @@ class AssignmentGarbageCollectorCommandTest extends KernelTestCase
 
         $this->assertEquals(0, $this->commandTester->execute([]));
         $this->assertStringContainsString(
-            "[OK] Total of '15' stuck assignments were successfully collected.",
+            "[OK] Total of '10' stuck assignments were successfully collected.",
             $this->commandTester->getDisplay()
         );
 
         $this->assertCount(
-            15,
+            10,
             $this->getRepository(Assignment::class)->findBy(['state' => Assignment::STATE_STARTED])
         );
     }
@@ -93,11 +93,11 @@ class AssignmentGarbageCollectorCommandTest extends KernelTestCase
             ]
         ));
         $this->assertStringContainsString(
-            "[OK] Total of '15' stuck assignments were successfully collected.",
+            "[OK] Total of '10' stuck assignments were successfully collected.",
             $this->commandTester->getDisplay()
         );
 
-        for ($i = 1; $i <= 5; $i++) {
+        for ($i = 1; $i <= 3; $i++) {
             $this->assertHasLogRecordWithMessage(
                 sprintf(
                     "Assignment with id='%s' of user with username='%s' has been collected and marked as 'completed' by garbage collector.",
@@ -108,7 +108,7 @@ class AssignmentGarbageCollectorCommandTest extends KernelTestCase
             );
         }
 
-        for ($i = 6; $i <= 15; $i++) {
+        for ($i = 4; $i <= 10; $i++) {
             $this->assertHasLogRecordWithMessage(
                 sprintf(
                     "Assignment with id='%s' of user with username='%s' has been collected and marked as 'ready' by garbage collector.",
@@ -140,7 +140,7 @@ class AssignmentGarbageCollectorCommandTest extends KernelTestCase
             )
         );
         $this->assertStringContainsString(
-            "[OK] Total of '15' stuck assignments were successfully collected.",
+            "[OK] Total of '10' stuck assignments were successfully collected.",
             $this->commandTester->getDisplay()
         );
 

--- a/tests/Integration/Repository/AssignmentRepositoryTest.php
+++ b/tests/Integration/Repository/AssignmentRepositoryTest.php
@@ -53,8 +53,8 @@ class AssignmentRepositoryTest extends KernelTestCase
         $dateTime = (new DateTime())->add(new DateInterval('P1D'));
         $assignments = $this->subject->findAllByStateAndUpdatedAtPaginated(Assignment::STATE_STARTED, $dateTime);
 
-        $this->assertCount(10, $assignments->getIterator());
-        $this->assertCount(10, $assignments);
+        $this->assertCount(15, $assignments->getIterator());
+        $this->assertCount(15, $assignments);
     }
 
     public function testItCanReturnAssignmentsByStateAndUpdatedAtPaginated(): void
@@ -63,6 +63,6 @@ class AssignmentRepositoryTest extends KernelTestCase
         $assignments = $this->subject->findAllByStateAndUpdatedAtPaginated(Assignment::STATE_STARTED, $dateTime, 2, 3);
 
         $this->assertCount(3, $assignments->getIterator());
-        $this->assertCount(10, $assignments);
+        $this->assertCount(15, $assignments);
     }
 }

--- a/tests/Integration/Repository/AssignmentRepositoryTest.php
+++ b/tests/Integration/Repository/AssignmentRepositoryTest.php
@@ -53,8 +53,8 @@ class AssignmentRepositoryTest extends KernelTestCase
         $dateTime = (new DateTime())->add(new DateInterval('P1D'));
         $assignments = $this->subject->findAllByStateAndUpdatedAtPaginated(Assignment::STATE_STARTED, $dateTime);
 
-        $this->assertCount(15, $assignments->getIterator());
-        $this->assertCount(15, $assignments);
+        $this->assertCount(10, $assignments->getIterator());
+        $this->assertCount(10, $assignments);
     }
 
     public function testItCanReturnAssignmentsByStateAndUpdatedAtPaginated(): void
@@ -63,6 +63,6 @@ class AssignmentRepositoryTest extends KernelTestCase
         $assignments = $this->subject->findAllByStateAndUpdatedAtPaginated(Assignment::STATE_STARTED, $dateTime, 2, 3);
 
         $this->assertCount(3, $assignments->getIterator());
-        $this->assertCount(15, $assignments);
+        $this->assertCount(10, $assignments);
     }
 }

--- a/tests/Unit/Entity/AssignmentTest.php
+++ b/tests/Unit/Entity/AssignmentTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; under version 2
+ *  of the License (non-upgradable).
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  Copyright (c) 2019 (original work) Open Assessment Technologies S.A.
+ */
+
+namespace App\Tests\Unit\Entity;
+
+use App\Entity\Assignment;
+use App\Entity\LineItem;
+use PHPUnit\Framework\TestCase;
+
+class AssignmentTest extends TestCase
+{
+    /** @var LineItem */
+    private $lineItem;
+
+    /** @var Assignment */
+    private $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->lineItem = new LineItem();
+        $this->subject = new Assignment();
+        $this->subject->setLineItem($this->lineItem);
+    }
+
+    public function testItUpdatesStateAsCompletedIfMaxAttemptsIsReached(): void
+    {
+        $this->lineItem->setMaxAttempts(1);
+
+        $this->subject->incrementAttemptsCount();
+
+        $this->subject->complete();
+
+        $this->assertEquals(
+            Assignment::STATE_COMPLETED,
+            $this->subject->getState()
+        );
+    }
+
+    public function testItUpdatesStateAsReadyIfMaxAttemptsIs0(): void
+    {
+        $this->lineItem->setMaxAttempts(0);
+
+        $this->subject->incrementAttemptsCount();
+
+        $this->subject->complete();
+
+        $this->assertEquals(
+            Assignment::STATE_READY,
+            $this->subject->getState()
+        );
+    }
+
+    public function testItUpdatesStateAsReadyIfMaxAttemptsIsNotReached(): void
+    {
+        $this->lineItem->setMaxAttempts(2);
+
+        $this->subject->incrementAttemptsCount();
+
+        $this->subject->complete();
+
+        $this->assertEquals(
+            Assignment::STATE_READY,
+            $this->subject->getState()
+        );
+    }
+}

--- a/tests/Unit/Entity/AssignmentTest.php
+++ b/tests/Unit/Entity/AssignmentTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  *  This program is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU General Public License
@@ -19,6 +17,8 @@ declare(strict_types=1);
  *
  *  Copyright (c) 2019 (original work) Open Assessment Technologies S.A.
  */
+
+declare(strict_types=1);
 
 namespace App\Tests\Unit\Entity;
 

--- a/tests/Unit/Service/CompleteUserAssignmentServiceTest.php
+++ b/tests/Unit/Service/CompleteUserAssignmentServiceTest.php
@@ -70,12 +70,14 @@ class CompleteUserAssignmentServiceTest extends TestCase
             ->setInfrastructure(new Infrastructure())
             ->setUri('uri')
             ->setLabel('label')
-            ->setSlug('slug');
+            ->setSlug('slug')
+            ->setMaxAttempts(1);
 
         $assignment = (new Assignment())
             ->setState(Assignment::STATE_STARTED)
             ->setLineItem($lineItem)
-            ->setUser($user);
+            ->setUser($user)
+            ->setAttemptsCount(1);
 
         $this->assignmentRepository
             ->expects($this->once())
@@ -88,6 +90,43 @@ class CompleteUserAssignmentServiceTest extends TestCase
             ->method('persist')
             ->with($this->callback(static function (Assignment $assignment) {
                 return $assignment->getState() === Assignment::STATE_COMPLETED;
+            }));
+
+        $this->assignmentRepository
+            ->expects($this->once())
+            ->method('flush');
+
+        $this->subject->markAssignmentAsCompleted(5);
+    }
+
+    public function testItMarksAssignmentAsReady(): void
+    {
+        $user = (new User())->setUsername('expectedUsername');
+
+        $lineItem = (new LineItem())
+            ->setInfrastructure(new Infrastructure())
+            ->setUri('uri')
+            ->setLabel('label')
+            ->setSlug('slug')
+            ->setMaxAttempts(2);
+
+        $assignment = (new Assignment())
+            ->setState(Assignment::STATE_STARTED)
+            ->setLineItem($lineItem)
+            ->setUser($user)
+            ->setAttemptsCount(1);
+
+        $this->assignmentRepository
+            ->expects($this->once())
+            ->method('find')
+            ->with(5)
+            ->willReturn($assignment);
+
+        $this->assignmentRepository
+            ->expects($this->once())
+            ->method('persist')
+            ->with($this->callback(static function (Assignment $assignment) {
+                return $assignment->getState() === Assignment::STATE_READY;
             }));
 
         $this->assignmentRepository


### PR DESCRIPTION
* Added new property _attemptsCount_ to _Assignment_ entity
* Upon user ingestion assignments is created with 0 as attempt count
* Attempt counter is increased upon LTI launch
* LTI outcome call sets the assignment status to READY if no maximum attempts or current attempt count is lower than max attempts
* Garbage collector command sets the assignment status to READY if no maximum attempts or current attempt count is lower than max attempts
* New property _attemptsCount_ is be returned in every API response

✔️ Tests running
✔️ PHPStan with max level
✔️ Infection 99% MSI