### PR TITLE
Feature/tdp 61 modify listuserassignmentsaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Changed garbage collection state update to `ready` if `Assignment` has additional attempts available.
 - Increment the `attemptsCount` on upon LTI Launch if state is not started.
 - Set default value of `0` for `attemptsCount` for new assignments during user ingestion.
-- The `/api/v1//assignments` endpoint now returns all users assignments (available or not).
+- The `/api/v1/assignments` endpoint now returns all users assignments (available or not).
 
 ## 1.5.0 - 2020-06-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Changed garbage collection state update to `ready` if `Assignment` has additional attempts available.
 - Increment the `attemptsCount` on upon LTI Launch.
 - Set default value of `0` for `attemptsCount` for new assignments during user ingestion.
+- The `/api/v1//assignments` endpoint now returns all users assignments (available or not).
 
 ## 1.5.0 - 2020-06-17
 

--- a/openapi/api_v1.yml
+++ b/openapi/api_v1.yml
@@ -81,7 +81,7 @@ paths:
   /assignments:
     get:
       summary: List user assignments
-      description: List current authenticated user available assignments (not cancelled, and with valid dates)
+      description: List current authenticated user assignments
       tags:
         - Assignments
       security:

--- a/src/Action/Assignment/ListUserAssignmentsAction.php
+++ b/src/Action/Assignment/ListUserAssignmentsAction.php
@@ -42,6 +42,6 @@ class ListUserAssignmentsAction
      */
     public function __invoke(UserInterface $user): Response
     {
-        return $this->responder->createJsonResponse(['assignments' => $user->getAvailableAssignments()]);
+        return $this->responder->createJsonResponse(['assignments' => $user->getAssignments()]);
     }
 }

--- a/tests/Functional/Action/Assignment/ListUserAssignmentsActionTest.php
+++ b/tests/Functional/Action/Assignment/ListUserAssignmentsActionTest.php
@@ -64,10 +64,8 @@ class ListUserAssignmentsActionTest extends WebTestCase
         );
     }
 
-    public function testItReturnListOfUserAssignmentsWhenCurrentDateMatchesLineItemAvailability(): void
+    public function testItReturnListOfUserAssignments(): void
     {
-        Carbon::setTestNow(Carbon::createFromDate(2019, 1, 1));
-
         /** @var UserRepository $userRepository */
         $userRepository = $this->getRepository(User::class);
         $user = $userRepository->getByUsernameWithAssignments('user1');
@@ -97,26 +95,5 @@ class ListUserAssignmentsActionTest extends WebTestCase
                 ],
             ],
         ], json_decode($this->kernelBrowser->getResponse()->getContent(), true));
-    }
-
-    public function testItReturnListOfUserAssignmentsWhenCurrentDateDoesNotMatchLineItemAvailability(): void
-    {
-        Carbon::setTestNow(Carbon::createFromDate(2022, 1, 1));
-
-        /** @var UserRepository $userRepository */
-        $userRepository = $this->getRepository(User::class);
-        $user = $userRepository->getByUsernameWithAssignments('user1');
-
-        $this->logInAs($user, $this->kernelBrowser);
-
-        $this->kernelBrowser->request(Request::METHOD_GET, '/api/v1/assignments');
-
-        $this->assertEquals(Response::HTTP_OK, $this->kernelBrowser->getResponse()->getStatusCode());
-        $this->assertEquals(
-            [
-                'assignments' => [],
-            ],
-            json_decode($this->kernelBrowser->getResponse()->getContent(), true)
-        );
     }
 }


### PR DESCRIPTION
The _/api/v1/assignments_ endpoint now returns **all available user assignments** without filtering on their availability.

✔️ Tests passing
✔️ PHPStan passing
✔️ Infection passing