### PR TITLE
INV-273 Persisting assignment before flushing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@
 - Added xml namespace environment variable for ReplaceResultRequest, used by ReplaceResultSourceIdExtractor, to follow [LTI 1.1 specifications](https://www.imsglobal.org/specs/ltiv1p1p1/implementation-guide#toc-26).
 - Fixed [security breach](https://symfony.com/blog/cve-2020-15094-prevent-rce-when-calling-untrusted-remote-with-cachinghttpclient) by updating symfony/http-kernel to version 4.4.13. 
 
+## 1.6.3 - TBD
+
+### Fixed
+- Fixed issue where attemptCount was always returning same value.  
+
+### Added
+- Added xml namespace environment variable for ReplaceResultRequest, used by ReplaceResultSourceIdExtractor, to follow [LTI 1.1 specifications](https://www.imsglobal.org/specs/ltiv1p1p1/implementation-guide#toc-26).
+- Fixed [security breach](https://symfony.com/blog/cve-2020-15094-prevent-rce-when-calling-untrusted-remote-with-cachinghttpclient) by updating symfony/http-kernel to version 4.4.13. 
+
 ## 1.6.2 - 2020-09-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,7 @@
 ### Added
 - Added xml namespace environment variable for ReplaceResultRequest, used by ReplaceResultSourceIdExtractor, to follow [LTI 1.1 specifications](https://www.imsglobal.org/specs/ltiv1p1p1/implementation-guide#toc-26).
 - Fixed [security breach](https://symfony.com/blog/cve-2020-15094-prevent-rce-when-calling-untrusted-remote-with-cachinghttpclient) by updating symfony/http-kernel to version 4.4.13. 
-
-## 1.6.3 - TBD
-
-### Fixed
-- Fixed issue where attemptCount was always returning same value.  
-
-### Added
-- Added xml namespace environment variable for ReplaceResultRequest, used by ReplaceResultSourceIdExtractor, to follow [LTI 1.1 specifications](https://www.imsglobal.org/specs/ltiv1p1p1/implementation-guide#toc-26).
-- Fixed [security breach](https://symfony.com/blog/cve-2020-15094-prevent-rce-when-calling-untrusted-remote-with-cachinghttpclient) by updating symfony/http-kernel to version 4.4.13. 
+- Fixed issue where attemptCount was always returning same value.
 
 ## 1.6.2 - 2020-09-03
 

--- a/src/Action/Lti/GetUserAssignmentLtiLinkAction.php
+++ b/src/Action/Lti/GetUserAssignmentLtiLinkAction.php
@@ -76,6 +76,7 @@ class GetUserAssignmentLtiLinkAction
                     ->incrementAttemptsCount();
             }
 
+            $this->entityManager->persist($assignment);
             $this->entityManager->flush();
 
             $this->logger->info(


### PR DESCRIPTION
This PR fixes an issue where the `attemptCount` parameter was aways returning same value. We are now persisting the assignment when updating it to "started"