### PR TITLE
Release 1.7.0

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -41,6 +41,8 @@ LTI_LAUNCH_PRESENTATION_LOCALE=en-EN
 LTI_LAUNCH_PRESENTATION_RETURN_URL=http://localhost:8000/index.html
 # Possible values for LTI Instance load balancer strategy: username or userGroupId
 LTI_INSTANCE_LOAD_BALANCING_STRATEGY=username
+#Lti Outcome XML namespace
+LTI_OUTCOME_XML_NAMESPACE=http://www.imsglobal.org/services/ltiv1p1/xsd/imsoms_v1p0
 ###< LTI ###
 
 ###> blackfire ###

--- a/.env.docker
+++ b/.env.docker
@@ -41,6 +41,8 @@ LTI_LAUNCH_PRESENTATION_LOCALE=en-EN
 LTI_LAUNCH_PRESENTATION_RETURN_URL=http://localhost:8000/index.html
 # Possible values for LTI Instance load balancer strategy: username or userGroupId
 LTI_INSTANCE_LOAD_BALANCING_STRATEGY=username
+#Lti Outcome XML namespace
+LTI_OUTCOME_XML_NAMESPACE=http://www.imsglobal.org/services/ltiv1p1/xsd/imsoms_v1p0
 ###< LTI ###
 
 ###> blackfire ###

--- a/.env.test
+++ b/.env.test
@@ -30,6 +30,8 @@ LTI_LAUNCH_PRESENTATION_LOCALE=en-EN
 LTI_LAUNCH_PRESENTATION_RETURN_URL='http://example.com/index.html'
 # Possible values for LTI Instance load balancer strategy: username or userGroupId
 LTI_INSTANCE_LOAD_BALANCING_STRATEGY=username
+#Lti Outcome XML namespace
+LTI_OUTCOME_XML_NAMESPACE=http://www.imsglobal.org/services/ltiv1p1/xsd/imsoms_v1p0
 ###< LTI ###
 
 ###> Assignment garbage collector ###

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.7.0 - To be released
+## 1.7.0 - 2020-09-16
 
 ### Added
 - Added xml namespace environment variable for ReplaceResultRequest, used by ReplaceResultSourceIdExtractor, to follow [LTI 1.1 specifications](https://www.imsglobal.org/specs/ltiv1p1p1/implementation-guide#toc-26).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.7.0 - To be released
+
+### Added
+- Added xml namespace environment variable for ReplaceResultRequest, used by ReplaceResultSourceIdExtractor, to follow [LTI 1.1 specifications](https://www.imsglobal.org/specs/ltiv1p1p1/implementation-guide#toc-26).
+- Fixed [security breach](https://symfony.com/blog/cve-2020-15094-prevent-rce-when-calling-untrusted-remote-with-cachinghttpclient) by updating symfony/http-kernel to version 4.4.13. 
+
 ## 1.6.2 - 2020-09-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 - Added xml namespace environment variable for ReplaceResultRequest, used by ReplaceResultSourceIdExtractor, to follow [LTI 1.1 specifications](https://www.imsglobal.org/specs/ltiv1p1p1/implementation-guide#toc-26).
+
+### Fixed
 - Fixed [security breach](https://symfony.com/blog/cve-2020-15094-prevent-rce-when-calling-untrusted-remote-with-cachinghttpclient) by updating symfony/http-kernel to version 4.4.13. 
 - Fixed issue where attemptCount was always returning same value.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - Added xml namespace environment variable for ReplaceResultRequest, used by ReplaceResultSourceIdExtractor, to follow [LTI 1.1 specifications](https://www.imsglobal.org/specs/ltiv1p1p1/implementation-guide#toc-26).
 - Fixed [security breach](https://symfony.com/blog/cve-2020-15094-prevent-rce-when-calling-untrusted-remote-with-cachinghttpclient) by updating symfony/http-kernel to version 4.4.13. 
+- Fixed issue where attemptCount was always returning same value.
 
 ## 1.6.2 - 2020-09-03
 

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -98,3 +98,7 @@ services:
 
     Ramsey\Uuid\UuidFactoryInterface:
         class: Ramsey\Uuid\UuidFactory
+
+    App\Lti\Extractor\ReplaceResultSourceIdExtractor:
+        arguments:
+            $xmlNamespace: '%env(LTI_OUTCOME_XML_NAMESPACE)%'

--- a/docs/devops/devops-documentation.md
+++ b/docs/devops/devops-documentation.md
@@ -58,6 +58,7 @@ The main configuration file is `.env`, located in root folder.
 | LTI_LAUNCH_PRESENTATION_RETURN_URL | Frontend LTI return link |
 | LTI_LAUNCH_PRESENTATION_LOCALE | Defines the localisation of TAO instance [default: `en-EN`] |
 | LTI_INSTANCE_LOAD_BALANCING_STRATEGY | Defines the [LTI load balancing strategy](#lti-load-balancing-strategy) [default: `username`] |
+| LTI_OUTCOME_XML_NAMESPACE | Defines the LTI outcome XML namespace [default: `http://www.imsglobal.org/services/ltiv1p1/xsd/imsoms_v1p0`] |
 
 #### Blackfire related environment variables
 

--- a/src/Action/Lti/GetUserAssignmentLtiLinkAction.php
+++ b/src/Action/Lti/GetUserAssignmentLtiLinkAction.php
@@ -76,6 +76,7 @@ class GetUserAssignmentLtiLinkAction
                     ->incrementAttemptsCount();
             }
 
+            $this->entityManager->persist($assignment);
             $this->entityManager->flush();
 
             $this->logger->info(

--- a/src/Lti/Extractor/ReplaceResultSourceIdExtractor.php
+++ b/src/Lti/Extractor/ReplaceResultSourceIdExtractor.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  *  This program is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU General Public License
@@ -20,6 +18,8 @@ declare(strict_types=1);
  *  Copyright (c) 2019 (original work) Open Assessment Technologies S.A.
  */
 
+declare(strict_types=1);
+
 namespace App\Lti\Extractor;
 
 use App\Exception\InvalidLtiReplaceResultBodyException;
@@ -28,6 +28,14 @@ use Throwable;
 
 class ReplaceResultSourceIdExtractor
 {
+    /** @var string */
+    private $xmlNamespace;
+
+    public function __construct(string $xmlNamespace)
+    {
+        $this->xmlNamespace = $xmlNamespace;
+    }
+
     /**
      * @throws InvalidLtiReplaceResultBodyException
      */
@@ -39,7 +47,7 @@ class ReplaceResultSourceIdExtractor
             throw new InvalidLtiReplaceResultBodyException();
         }
 
-        $xml->registerXPathNamespace('x', 'http://www.imsglobal.org/lis/oms1p0/pox');
+        $xml->registerXPathNamespace('x', $this->xmlNamespace);
 
         $sourceIdNodes = $xml->xpath(
             '/x:imsx_POXEnvelopeRequest/x:imsx_POXBody/x:replaceResultRequest/x:resultRecord/x:sourcedGUID/x:sourcedId/text()'

--- a/tests/Resources/LtiOutcome/invalid_replace_result_body_missing_id.xml
+++ b/tests/Resources/LtiOutcome/invalid_replace_result_body_missing_id.xml
@@ -1,5 +1,5 @@
 <?xml version = "1.0" encoding = "UTF-8"?>
-<imsx_POXEnvelopeRequest xmlns = "http://www.imsglobal.org/lis/oms1p0/pox">
+<imsx_POXEnvelopeRequest xmlns = "http://www.imsglobal.org/services/ltiv1p1/xsd/imsoms_v1p0">
     <imsx_POXHeader>
         <imsx_POXRequestHeaderInfo>
             <imsx_version>V1.0</imsx_version>

--- a/tests/Resources/LtiOutcome/invalid_replace_result_body_wrong_namespace.xml
+++ b/tests/Resources/LtiOutcome/invalid_replace_result_body_wrong_namespace.xml
@@ -1,5 +1,5 @@
 <?xml version = "1.0" encoding = "UTF-8"?>
-<imsx_POXEnvelopeRequest xmlns = "http://www.imsglobal.org/services/ltiv1p1/xsd/imsoms_v1p0">
+<imsx_POXEnvelopeRequest xmlns = "ttp://www.imsglobal.org/lis/oms1p0/pox">
     <imsx_POXHeader>
         <imsx_POXRequestHeaderInfo>
             <imsx_version>V1.0</imsx_version>
@@ -10,7 +10,7 @@
         <replaceResultRequest>
             <resultRecord>
                 <sourcedGUID>
-                    <sourcedId>1000000000</sourcedId>
+                    <sourcedId>1</sourcedId>
                 </sourcedGUID>
                 <result>
                     <resultScore>

--- a/tests/Resources/LtiOutcome/valid_replace_result_body.xml
+++ b/tests/Resources/LtiOutcome/valid_replace_result_body.xml
@@ -1,5 +1,5 @@
 <?xml version = "1.0" encoding = "UTF-8"?>
-<imsx_POXEnvelopeRequest xmlns = "http://www.imsglobal.org/lis/oms1p0/pox">
+<imsx_POXEnvelopeRequest xmlns = "http://www.imsglobal.org/services/ltiv1p1/xsd/imsoms_v1p0">
     <imsx_POXHeader>
         <imsx_POXRequestHeaderInfo>
             <imsx_version>V1.0</imsx_version>

--- a/tests/Resources/LtiOutcome/valid_replace_result_body_with_old_namespace.xml
+++ b/tests/Resources/LtiOutcome/valid_replace_result_body_with_old_namespace.xml
@@ -1,5 +1,5 @@
 <?xml version = "1.0" encoding = "UTF-8"?>
-<imsx_POXEnvelopeRequest xmlns = "http://www.imsglobal.org/services/ltiv1p1/xsd/imsoms_v1p0">
+<imsx_POXEnvelopeRequest xmlns = "http://www.imsglobal.org/lis/oms1p0/pox">
     <imsx_POXHeader>
         <imsx_POXRequestHeaderInfo>
             <imsx_version>V1.0</imsx_version>
@@ -10,7 +10,7 @@
         <replaceResultRequest>
             <resultRecord>
                 <sourcedGUID>
-                    <sourcedId>1000000000</sourcedId>
+                    <sourcedId>1</sourcedId>
                 </sourcedGUID>
                 <result>
                     <resultScore>

--- a/tests/Unit/Lti/Extractor/ReplaceResultSourceIdExtractorTest.php
+++ b/tests/Unit/Lti/Extractor/ReplaceResultSourceIdExtractorTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  *  This program is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU General Public License
@@ -20,6 +18,8 @@ declare(strict_types=1);
  *  Copyright (c) 2019 (original work) Open Assessment Technologies S.A.
  */
 
+declare(strict_types=1);
+
 namespace App\Tests\Unit\Lti\Extractor;
 
 use App\Exception\InvalidLtiReplaceResultBodyException;
@@ -28,12 +28,18 @@ use PHPUnit\Framework\TestCase;
 
 class ReplaceResultSourceIdExtractorTest extends TestCase
 {
+    private const LTI_OUTCOME_XML_NAMESPACE = 'http://www.imsglobal.org/services/ltiv1p1/xsd/imsoms_v1p0';
+    private const OLD_LTI_OUTCOME_XML_NAMESPACE = 'http://www.imsglobal.org/lis/oms1p0/pox';
+
     public function testItCanExtractSourceId(): void
     {
-        $subject = new ReplaceResultSourceIdExtractor();
+        $subject = new ReplaceResultSourceIdExtractor(self::LTI_OUTCOME_XML_NAMESPACE);
 
         /** @var string $xmlContent */
-        $xmlContent = file_get_contents(__DIR__ . '/../../../Resources/LtiOutcome/valid_replace_result_body.xml');
+        $xmlContent = file_get_contents(
+            dirname(__DIR__, 3) . DIRECTORY_SEPARATOR
+            . 'Resources/LtiOutcome/valid_replace_result_body.xml'
+        );
 
         $this->assertEquals(1, $subject->extractSourceId($xmlContent));
     }
@@ -42,20 +48,36 @@ class ReplaceResultSourceIdExtractorTest extends TestCase
     {
         $this->expectException(InvalidLtiReplaceResultBodyException::class);
 
-        $subject = new ReplaceResultSourceIdExtractor();
+        $subject = new ReplaceResultSourceIdExtractor(self::LTI_OUTCOME_XML_NAMESPACE);
 
         $subject->extractSourceId('invalid');
+    }
+
+    public function testItThrowsInvalidLtiReplaceResultBodyExceptionOnInvalidXmlNamespace(): void
+    {
+        $this->expectException(InvalidLtiReplaceResultBodyException::class);
+
+        $subject = new ReplaceResultSourceIdExtractor(self::LTI_OUTCOME_XML_NAMESPACE);
+
+        /** @var string $xmlContent */
+        $xmlContent = file_get_contents(
+            dirname(__DIR__, 3) . DIRECTORY_SEPARATOR
+            . 'Resources/LtiOutcome/invalid_replace_result_body_wrong_namespace.xml'
+        );
+
+        $subject->extractSourceId($xmlContent);
     }
 
     public function testItThrowsInvalidLtiReplaceResultBodyExceptionOnMissingId(): void
     {
         $this->expectException(InvalidLtiReplaceResultBodyException::class);
 
-        $subject = new ReplaceResultSourceIdExtractor();
+        $subject = new ReplaceResultSourceIdExtractor(self::LTI_OUTCOME_XML_NAMESPACE);
 
         /** @var string $xmlContent */
         $xmlContent = file_get_contents(
-            __DIR__ . '/../../../Resources/LtiOutcome/invalid_replace_result_body_missing_id.xml'
+            dirname(__DIR__, 3) . DIRECTORY_SEPARATOR
+            . 'Resources/LtiOutcome/invalid_replace_result_body_missing_id.xml'
         );
 
         $subject->extractSourceId($xmlContent);


### PR DESCRIPTION
### Added
- Added xml namespace environment variable for ReplaceResultRequest, used by ReplaceResultSourceIdExtractor, to follow [LTI 1.1 specifications](https://www.imsglobal.org/specs/ltiv1p1p1/implementation-guide#toc-26).

### Fixed
- Fixed [security breach](https://symfony.com/blog/cve-2020-15094-prevent-rce-when-calling-untrusted-remote-with-cachinghttpclient) by updating symfony/http-kernel to version 4.4.13. 
- Fixed issue where attemptCount was always returning same value.