### PR TITLE
Native ingestion and cache warmup performance improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.8.1 - 2020-10-14
+
+### Changed
+- Switched from offset based pagination to cursor based in `DoctrineResultCacheWarmerCommand` for better performance.
+- Switched from ORM to native queries in `NativeUserIngesterCommand` for better performance.
+
+### Fixed
+- Fixed bug in `DoctrineResultCacheWarmerCommand` where lack of order by clause caused wrong pagination.
+
 ## 1.8.0 - 2020-10-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Switched from ORM to native queries in `NativeUserIngesterCommand` for better performance.
 
 ### Fixed
-- Fixed bug in `DoctrineResultCacheWarmerCommand` where lack of order by clause caused wrong pagination.
+- Fixed bug in `DoctrineResultCacheWarmerCommand` where lack of order by clause caused wrong pagination with PostgreSQL.
 
 ## 1.8.0 - 2020-10-08
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 >REST back-end service intending to mimic a simplified version of OneRoster IMS specification.
 
-![current version](https://img.shields.io/badge/version-1.8.0-green.svg)
+![current version](https://img.shields.io/badge/version-1.8.1-green.svg)
 [![License: GPL v2](https://img.shields.io/badge/License-GPL%20v2-blue.svg)](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html)
 ![coverage](https://img.shields.io/badge/coverage-100%25-green.svg)
 

--- a/tests/Functional/Command/Cache/DoctrineResultCacheWarmerCommandTest.php
+++ b/tests/Functional/Command/Cache/DoctrineResultCacheWarmerCommandTest.php
@@ -334,6 +334,7 @@ class DoctrineResultCacheWarmerCommandTest extends KernelTestCase
             [
                 '--modulo' => 6,
                 '--remainder' => 0,
+                '--batch-size' => 10,
             ],
             [
                 'capture_stderr_separately' => true,
@@ -346,6 +347,7 @@ class DoctrineResultCacheWarmerCommandTest extends KernelTestCase
             [
                 '--modulo' => 6,
                 '--remainder' => 1,
+                '--batch-size' => 10,
             ],
             [
                 'capture_stderr_separately' => true,
@@ -358,6 +360,7 @@ class DoctrineResultCacheWarmerCommandTest extends KernelTestCase
             [
                 '--modulo' => 6,
                 '--remainder' => 2,
+                '--batch-size' => 10,
             ],
             [
                 'capture_stderr_separately' => true,
@@ -370,6 +373,7 @@ class DoctrineResultCacheWarmerCommandTest extends KernelTestCase
             [
                 '--modulo' => 6,
                 '--remainder' => 3,
+                '--batch-size' => 10,
             ],
             [
                 'capture_stderr_separately' => true,
@@ -382,6 +386,7 @@ class DoctrineResultCacheWarmerCommandTest extends KernelTestCase
             [
                 '--modulo' => 6,
                 '--remainder' => 4,
+                '--batch-size' => 10,
             ],
             [
                 'capture_stderr_separately' => true,
@@ -394,6 +399,7 @@ class DoctrineResultCacheWarmerCommandTest extends KernelTestCase
             [
                 '--modulo' => 6,
                 '--remainder' => 5,
+                '--batch-size' => 10,
             ],
             [
                 'capture_stderr_separately' => true,


### PR DESCRIPTION
### Changed
- Switched from offset based pagination to cursor based in `DoctrineResultCacheWarmerCommand` for better performance.
- Switched from ORM to native queries in `NativeUserIngesterCommand` for better performance.

### Fixed
- Fixed bug in `DoctrineResultCacheWarmerCommand` where lack of order by clause caused wrong pagination with PostgreSQL.