### PR TITLE
Release v1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.8.1 - 2020-10-15
+## 1.8.1 - 2020-10-27
 
 ### Changed
 - Switched from offset based pagination to cursor based in `DoctrineResultCacheWarmerCommand` for better performance.
@@ -8,6 +8,7 @@
 
 ### Fixed
 - Fixed bug in `DoctrineResultCacheWarmerCommand` where lack of order by clause caused wrong pagination with PostgreSQL.
+- Fixed `OAuthSignatureValidationSubscriber` to read LTI credentials from configuration instead of database.
 
 ## 1.8.0 - 2020-10-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.8.1 - 2020-10-14
+
+### Changed
+- Switched from offset based pagination to cursor based in `DoctrineResultCacheWarmerCommand` for better performance.
+- Switched from ORM to native queries in `NativeUserIngesterCommand` for better performance.
+
+### Fixed
+- Fixed bug in `DoctrineResultCacheWarmerCommand` where lack of order by clause caused wrong pagination with PostgreSQL.
+
 ## 1.8.0 - 2020-10-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.8.1 - 2020-10-14
+## 1.8.1 - 2020-10-15
 
 ### Changed
 - Switched from offset based pagination to cursor based in `DoctrineResultCacheWarmerCommand` for better performance.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 >REST back-end service intending to mimic a simplified version of OneRoster IMS specification.
 
-![current version](https://img.shields.io/badge/version-1.8.0-green.svg)
+![current version](https://img.shields.io/badge/version-1.8.1-green.svg)
 [![License: GPL v2](https://img.shields.io/badge/License-GPL%20v2-blue.svg)](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html)
 ![coverage](https://img.shields.io/badge/coverage-100%25-green.svg)
 

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -1,6 +1,8 @@
 parameters:
     locale: 'en'
     app.route_prefix: '%env(resolve:APP_ROUTE_PREFIX)%'
+    app.lti.key: '%env(resolve:LTI_KEY)%'
+    app.lti.secret: '%env(resolve:LTI_SECRET)%'
 
 services:
     _defaults:
@@ -15,8 +17,8 @@ services:
             $ltiLaunchPresentationLocale: '%env(resolve:LTI_LAUNCH_PRESENTATION_LOCALE)%'
             $ltiInstancesLoadBalancerEnabled: '%env(bool:LTI_ENABLE_INSTANCES_LOAD_BALANCER)%'
             $appApiKey: '%env(resolve:APP_API_KEY)%'
-            $ltiKey: '%env(resolve:LTI_KEY)%'
-            $ltiSecret: '%env(resolve:LTI_SECRET)%'
+            $ltiKey: '%app.lti.key%'
+            $ltiSecret: '%app.lti.secret%'
 
     _instanceof:
         App\Ingester\Ingester\IngesterInterface:

--- a/src/Entity/Infrastructure.php
+++ b/src/Entity/Infrastructure.php
@@ -68,21 +68,11 @@ class Infrastructure implements EntityInterface
         return $this;
     }
 
-    public function getLtiKey(): string
-    {
-        return $this->ltiKey;
-    }
-
     public function setLtiKey(string $ltiKey): self
     {
         $this->ltiKey = $ltiKey;
 
         return $this;
-    }
-
-    public function getLtiSecret(): string
-    {
-        return $this->ltiSecret;
     }
 
     public function setLtiSecret(string $ltiSecret): self

--- a/src/Repository/InfrastructureRepository.php
+++ b/src/Repository/InfrastructureRepository.php
@@ -38,17 +38,4 @@ class InfrastructureRepository extends AbstractRepository
     {
         parent::__construct($registry, Infrastructure::class);
     }
-
-    /**
-     * @throws NonUniqueResultException
-     */
-    public function getByLtiKey(string $ltiKey): ?Infrastructure
-    {
-        return $this
-            ->createQueryBuilder('i')
-            ->where('i.ltiKey = :ltiKey')
-            ->setParameter('ltiKey', $ltiKey)
-            ->getQuery()
-            ->getOneOrNullResult();
-    }
 }

--- a/tests/Functional/Action/Lti/UpdateLtiOutcomeActionTest.php
+++ b/tests/Functional/Action/Lti/UpdateLtiOutcomeActionTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  *  This program is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU General Public License
@@ -20,12 +18,12 @@ declare(strict_types=1);
  *  Copyright (c) 2019 (original work) Open Assessment Technologies S.A.
  */
 
+declare(strict_types=1);
+
 namespace App\Tests\Functional\Action\Lti;
 
 use App\Entity\Assignment;
-use App\Entity\Infrastructure;
 use App\Repository\AssignmentRepository;
-use App\Repository\InfrastructureRepository;
 use App\Security\OAuth\OAuthContext;
 use App\Security\OAuth\OAuthSigner;
 use App\Tests\Traits\DatabaseTestingTrait;
@@ -40,11 +38,20 @@ class UpdateLtiOutcomeActionTest extends WebTestCase
     /** @var KernelBrowser */
     private $kernelBrowser;
 
+    /** @var string */
+    private $testLtiKey;
+
+    /** @var string */
+    private $testLtiSecret;
+
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->kernelBrowser = self::createClient();
+        $this->testLtiKey = self::$container->getParameter('app.lti.key');
+        $this->testLtiSecret = self::$container->getParameter('app.lti.secret');
+
         $this->setUpDatabase();
         $this->loadFixtureByFilename('userWithReadyAssignment.yml');
     }
@@ -53,16 +60,14 @@ class UpdateLtiOutcomeActionTest extends WebTestCase
     {
         $this->kernelBrowser->request('POST', '/api/v1/lti/outcome');
 
-        $this->assertEquals(Response::HTTP_UNAUTHORIZED, $this->kernelBrowser->getResponse()->getStatusCode());
+        self::assertEquals(Response::HTTP_UNAUTHORIZED, $this->kernelBrowser->getResponse()->getStatusCode());
     }
 
     public function testItReturns401IfWrongAuthentication(): void
     {
-        $infrastructure = $this->getInfrastructure();
-
         $queryParameters = http_build_query([
             'oauth_body_hash' => 'bodyHash',
-            'oauth_consumer_key' => $infrastructure->getLtiKey(),
+            'oauth_consumer_key' => $this->testLtiKey,
             'oauth_nonce' => 'nonce',
             'oauth_signature' => 'signature',
             'oauth_signature_method' => 'HMAC-SHA1',
@@ -72,7 +77,7 @@ class UpdateLtiOutcomeActionTest extends WebTestCase
 
         $this->kernelBrowser->request(
             'POST',
-            '/api/v1/lti/outcome? '. $queryParameters,
+            '/api/v1/lti/outcome?' . $queryParameters,
             [],
             [],
             [
@@ -80,22 +85,20 @@ class UpdateLtiOutcomeActionTest extends WebTestCase
             ]
         );
 
-        $this->assertEquals(Response::HTTP_UNAUTHORIZED, $this->kernelBrowser->getResponse()->getStatusCode());
+        self::assertEquals(Response::HTTP_UNAUTHORIZED, $this->kernelBrowser->getResponse()->getStatusCode());
     }
 
     public function testItReturns200IfTheAuthenticationWorksAndAssignmentExists(): void
     {
-        $infrastructure = $this->getInfrastructure();
-
         $time = time();
-        $signature = $this->generateSignature($infrastructure, (string)$time);
+        $signature = $this->generateSignature((string)$time);
 
-        /** @var string $xmlBody **/
+        /** @var string $xmlBody * */
         $xmlBody = file_get_contents(__DIR__ . '/../../../Resources/LtiOutcome/valid_replace_result_body.xml');
 
         $queryParameters = http_build_query([
             'oauth_body_hash' => 'bodyHash',
-            'oauth_consumer_key' => $infrastructure->getLtiKey(),
+            'oauth_consumer_key' => $this->testLtiKey,
             'oauth_nonce' => 'nonce',
             'oauth_signature' => $signature,
             'oauth_signature_method' => 'HMAC-SHA1',
@@ -105,7 +108,7 @@ class UpdateLtiOutcomeActionTest extends WebTestCase
 
         $this->kernelBrowser->request(
             'POST',
-            '/api/v1/lti/outcome? '. $queryParameters,
+            '/api/v1/lti/outcome?' . $queryParameters,
             [],
             [],
             [
@@ -114,9 +117,9 @@ class UpdateLtiOutcomeActionTest extends WebTestCase
             $xmlBody
         );
 
-        $this->assertEquals(Response::HTTP_OK, $this->kernelBrowser->getResponse()->getStatusCode());
+        self::assertEquals(Response::HTTP_OK, $this->kernelBrowser->getResponse()->getStatusCode());
 
-        $this->assertEquals(
+        self::assertEquals(
             Assignment::STATE_READY,
             $this->getAssignment()->getState()
         );
@@ -124,16 +127,14 @@ class UpdateLtiOutcomeActionTest extends WebTestCase
 
     public function testItReturns400IfTheAuthenticationWorksButTheXmlIsInvalid(): void
     {
-        $infrastructure = $this->getInfrastructure();
-
         $time = time();
-        $signature = $this->generateSignature($infrastructure, (string)$time);
+        $signature = $this->generateSignature((string)$time);
 
         $xmlBody = 'test';
 
         $queryParameters = http_build_query([
             'oauth_body_hash' => 'bodyHash',
-            'oauth_consumer_key' => $infrastructure->getLtiKey(),
+            'oauth_consumer_key' => $this->testLtiKey,
             'oauth_nonce' => 'nonce',
             'oauth_signature' => $signature,
             'oauth_signature_method' => 'HMAC-SHA1',
@@ -143,7 +144,7 @@ class UpdateLtiOutcomeActionTest extends WebTestCase
 
         $this->kernelBrowser->request(
             'POST',
-            '/api/v1/lti/outcome? '. $queryParameters,
+            '/api/v1/lti/outcome?' . $queryParameters,
             [],
             [],
             [
@@ -152,9 +153,9 @@ class UpdateLtiOutcomeActionTest extends WebTestCase
             $xmlBody
         );
 
-        $this->assertEquals(Response::HTTP_BAD_REQUEST, $this->kernelBrowser->getResponse()->getStatusCode());
+        self::assertEquals(Response::HTTP_BAD_REQUEST, $this->kernelBrowser->getResponse()->getStatusCode());
 
-        $this->assertEquals(
+        self::assertEquals(
             Assignment::STATE_READY,
             $this->getAssignment()->getState()
         );
@@ -162,10 +163,8 @@ class UpdateLtiOutcomeActionTest extends WebTestCase
 
     public function testItReturns404IfTheAuthenticationWorksButTheAssignmentDoesNotExist(): void
     {
-        $infrastructure = $this->getInfrastructure();
-
         $time = time();
-        $signature = $this->generateSignature($infrastructure, (string)$time);
+        $signature = $this->generateSignature((string)$time);
 
         /** @var string $xmlBody */
         $xmlBody = file_get_contents(
@@ -174,7 +173,7 @@ class UpdateLtiOutcomeActionTest extends WebTestCase
 
         $queryParameters = http_build_query([
             'oauth_body_hash' => 'bodyHash',
-            'oauth_consumer_key' => $infrastructure->getLtiKey(),
+            'oauth_consumer_key' => $this->testLtiKey,
             'oauth_nonce' => 'nonce',
             'oauth_signature' => $signature,
             'oauth_signature_method' => 'HMAC-SHA1',
@@ -184,7 +183,7 @@ class UpdateLtiOutcomeActionTest extends WebTestCase
 
         $this->kernelBrowser->request(
             'POST',
-            '/api/v1/lti/outcome? '. $queryParameters,
+            '/api/v1/lti/outcome?' . $queryParameters,
             [],
             [],
             [
@@ -193,19 +192,19 @@ class UpdateLtiOutcomeActionTest extends WebTestCase
             $xmlBody
         );
 
-        $this->assertEquals(Response::HTTP_NOT_FOUND, $this->kernelBrowser->getResponse()->getStatusCode());
+        self::assertEquals(Response::HTTP_NOT_FOUND, $this->kernelBrowser->getResponse()->getStatusCode());
 
-        $this->assertEquals(
+        self::assertEquals(
             Assignment::STATE_READY,
             $this->getAssignment()->getState()
         );
     }
 
-    private function generateSignature(Infrastructure $infrastructure, string $time): string
+    private function generateSignature(string $time): string
     {
         $context = new OAuthContext(
             'bodyHash',
-            $infrastructure->getLtiKey(),
+            $this->testLtiKey,
             'nonce',
             'HMAC-SHA1',
             $time,
@@ -218,16 +217,8 @@ class UpdateLtiOutcomeActionTest extends WebTestCase
             $context,
             'http://localhost/api/v1/lti/outcome',
             'POST',
-            $infrastructure->getLtiSecret()
+            $this->testLtiSecret
         );
-    }
-
-    private function getInfrastructure(): Infrastructure
-    {
-        /** @var InfrastructureRepository $repository */
-        $repository = $this->getRepository(Infrastructure::class);
-
-        return $repository->find(1);
     }
 
     private function getAssignment(): Assignment

--- a/tests/Functional/Command/Cache/DoctrineResultCacheWarmerCommandTest.php
+++ b/tests/Functional/Command/Cache/DoctrineResultCacheWarmerCommandTest.php
@@ -334,6 +334,7 @@ class DoctrineResultCacheWarmerCommandTest extends KernelTestCase
             [
                 '--modulo' => 6,
                 '--remainder' => 0,
+                '--batch-size' => 10,
             ],
             [
                 'capture_stderr_separately' => true,
@@ -346,6 +347,7 @@ class DoctrineResultCacheWarmerCommandTest extends KernelTestCase
             [
                 '--modulo' => 6,
                 '--remainder' => 1,
+                '--batch-size' => 10,
             ],
             [
                 'capture_stderr_separately' => true,
@@ -358,6 +360,7 @@ class DoctrineResultCacheWarmerCommandTest extends KernelTestCase
             [
                 '--modulo' => 6,
                 '--remainder' => 2,
+                '--batch-size' => 10,
             ],
             [
                 'capture_stderr_separately' => true,
@@ -370,6 +373,7 @@ class DoctrineResultCacheWarmerCommandTest extends KernelTestCase
             [
                 '--modulo' => 6,
                 '--remainder' => 3,
+                '--batch-size' => 10,
             ],
             [
                 'capture_stderr_separately' => true,
@@ -382,6 +386,7 @@ class DoctrineResultCacheWarmerCommandTest extends KernelTestCase
             [
                 '--modulo' => 6,
                 '--remainder' => 4,
+                '--batch-size' => 10,
             ],
             [
                 'capture_stderr_separately' => true,
@@ -394,6 +399,7 @@ class DoctrineResultCacheWarmerCommandTest extends KernelTestCase
             [
                 '--modulo' => 6,
                 '--remainder' => 5,
+                '--batch-size' => 10,
             ],
             [
                 'capture_stderr_separately' => true,


### PR DESCRIPTION
### Changed
- Switched from offset based pagination to cursor based in `DoctrineResultCacheWarmerCommand` for better performance.
- Switched from ORM to native queries in `NativeUserIngesterCommand` for better performance.

### Fixed
- Fixed bug in `DoctrineResultCacheWarmerCommand` where lack of order by clause caused wrong pagination with PostgreSQL.
- Fixed `OAuthSignatureValidationSubscriber` to read LTI credentials from configuration instead of database.