### PR TITLE
RO-24 - Fixed LTI credentials handling in oauth signature validation subscriber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.8.1 - 2020-10-14
+## 1.8.1 - 2020-10-26
 
 ### Changed
 - Switched from offset based pagination to cursor based in `DoctrineResultCacheWarmerCommand` for better performance.
@@ -8,6 +8,7 @@
 
 ### Fixed
 - Fixed bug in `DoctrineResultCacheWarmerCommand` where lack of order by clause caused wrong pagination with PostgreSQL.
+- Fixed `OAuthSignatureValidationSubscriber` to read LTI credentials from configuration instead of database.
 
 ## 1.8.0 - 2020-10-08
 

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -1,6 +1,8 @@
 parameters:
     locale: 'en'
     app.route_prefix: '%env(resolve:APP_ROUTE_PREFIX)%'
+    app.lti.key: '%env(resolve:LTI_KEY)%'
+    app.lti.secret: '%env(resolve:LTI_SECRET)%'
 
 services:
     _defaults:
@@ -15,8 +17,8 @@ services:
             $ltiLaunchPresentationLocale: '%env(resolve:LTI_LAUNCH_PRESENTATION_LOCALE)%'
             $ltiInstancesLoadBalancerEnabled: '%env(bool:LTI_ENABLE_INSTANCES_LOAD_BALANCER)%'
             $appApiKey: '%env(resolve:APP_API_KEY)%'
-            $ltiKey: '%env(resolve:LTI_KEY)%'
-            $ltiSecret: '%env(resolve:LTI_SECRET)%'
+            $ltiKey: '%app.lti.key%'
+            $ltiSecret: '%app.lti.secret%'
 
     _instanceof:
         App\Ingester\Ingester\IngesterInterface:

--- a/src/Entity/Infrastructure.php
+++ b/src/Entity/Infrastructure.php
@@ -68,21 +68,11 @@ class Infrastructure implements EntityInterface
         return $this;
     }
 
-    public function getLtiKey(): string
-    {
-        return $this->ltiKey;
-    }
-
     public function setLtiKey(string $ltiKey): self
     {
         $this->ltiKey = $ltiKey;
 
         return $this;
-    }
-
-    public function getLtiSecret(): string
-    {
-        return $this->ltiSecret;
     }
 
     public function setLtiSecret(string $ltiSecret): self

--- a/src/Repository/InfrastructureRepository.php
+++ b/src/Repository/InfrastructureRepository.php
@@ -38,17 +38,4 @@ class InfrastructureRepository extends AbstractRepository
     {
         parent::__construct($registry, Infrastructure::class);
     }
-
-    /**
-     * @throws NonUniqueResultException
-     */
-    public function getByLtiKey(string $ltiKey): ?Infrastructure
-    {
-        return $this
-            ->createQueryBuilder('i')
-            ->where('i.ltiKey = :ltiKey')
-            ->setParameter('ltiKey', $ltiKey)
-            ->getQuery()
-            ->getOneOrNullResult();
-    }
 }

--- a/tests/Functional/Action/Lti/UpdateLtiOutcomeActionTest.php
+++ b/tests/Functional/Action/Lti/UpdateLtiOutcomeActionTest.php
@@ -77,7 +77,7 @@ class UpdateLtiOutcomeActionTest extends WebTestCase
 
         $this->kernelBrowser->request(
             'POST',
-            '/api/v1/lti/outcome? ' . $queryParameters,
+            '/api/v1/lti/outcome?' . $queryParameters,
             [],
             [],
             [
@@ -108,7 +108,7 @@ class UpdateLtiOutcomeActionTest extends WebTestCase
 
         $this->kernelBrowser->request(
             'POST',
-            '/api/v1/lti/outcome? ' . $queryParameters,
+            '/api/v1/lti/outcome?' . $queryParameters,
             [],
             [],
             [
@@ -144,7 +144,7 @@ class UpdateLtiOutcomeActionTest extends WebTestCase
 
         $this->kernelBrowser->request(
             'POST',
-            '/api/v1/lti/outcome? ' . $queryParameters,
+            '/api/v1/lti/outcome?' . $queryParameters,
             [],
             [],
             [
@@ -183,7 +183,7 @@ class UpdateLtiOutcomeActionTest extends WebTestCase
 
         $this->kernelBrowser->request(
             'POST',
-            '/api/v1/lti/outcome? ' . $queryParameters,
+            '/api/v1/lti/outcome?' . $queryParameters,
             [],
             [],
             [


### PR DESCRIPTION
- Fixed `OAuthSignatureValidationSubscriber` to read LTI credentials from configuration instead of database.