### PR TITLE
[RO-65] Enabled BooleanArgumentFlag rule in phpmd.xml

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -28,7 +28,6 @@ services:
         autoconfigure: true
         public: false
         bind:
-            $kernelDebug: '%kernel.debug%'
             $kernelEnvironment: '%kernel.environment%'
             $ltiLaunchPresentationReturnUrl: '%app.lti.launch_presentation_return_url%'
             $ltiLaunchPresentationLocale: '%app.lti.launch_presentation_locale%'

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -11,7 +11,6 @@
     </rule>
     <rule ref="rulesets/cleancode.xml">
         <exclude name="StaticAccess"/>
-        <exclude name="BooleanArgumentFlag"/> <!--todo-->
     </rule>
     <rule ref="rulesets/cleancode.xml/StaticAccess">
         <properties>

--- a/src/Responder/SerializerResponder.php
+++ b/src/Responder/SerializerResponder.php
@@ -25,6 +25,7 @@ namespace OAT\SimpleRoster\Responder;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 use Throwable;
 
@@ -35,13 +36,13 @@ class SerializerResponder
     /** @var SerializerInterface */
     private $serializer;
 
-    /** @var bool */
-    private $kernelDebug;
+    /** @var KernelInterface */
+    private $kernel;
 
-    public function __construct(SerializerInterface $serializer, bool $kernelDebug = false)
+    public function __construct(SerializerInterface $serializer, KernelInterface $kernel)
     {
         $this->serializer = $serializer;
-        $this->kernelDebug = $kernelDebug;
+        $this->kernel = $kernel;
     }
 
     /**
@@ -67,7 +68,7 @@ class SerializerResponder
             'message' => $statusCode < 500 ? $exception->getMessage() : self::DEFAULT_ERROR_MESSAGE,
         ];
 
-        if ($this->kernelDebug) {
+        if ($this->kernel->isDebug()) {
             $content['message'] = $exception->getMessage();
             $content['trace'] = $exception->getTraceAsString();
         }

--- a/tests/Integration/Responder/SerializerResponderTest.php
+++ b/tests/Integration/Responder/SerializerResponderTest.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 namespace OAT\SimpleRoster\Tests\Integration\Responder;
 
 use Exception;
+use OAT\SimpleRoster\Kernel;
 use OAT\SimpleRoster\Responder\SerializerResponder;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\HttpFoundation\Response;
@@ -32,7 +33,7 @@ use Throwable;
 
 class SerializerResponderTest extends KernelTestCase
 {
-    /** @var bool|null */
+    /** @var bool */
     private $debug = true;
 
     public function setUp(): void
@@ -170,8 +171,7 @@ class SerializerResponderTest extends KernelTestCase
 
     public function testCreate5xxHttpErrorJsonResponse(): void
     {
-        // To test with default debug parameter value, assuming `false`
-        $this->debug = null;
+        $this->debug = false;
 
         $exception = $this->createHttpException('custom error message', Response::HTTP_INTERNAL_SERVER_ERROR);
 
@@ -206,9 +206,9 @@ class SerializerResponderTest extends KernelTestCase
 
     private function createResponderInstance(): SerializerResponder
     {
-        return null !== $this->debug
-            ? new SerializerResponder(static::$container->get(SerializerInterface::class), $this->debug)
-            : new SerializerResponder(static::$container->get(SerializerInterface::class));
+        $kernel = new Kernel('test', $this->debug);
+
+        return new SerializerResponder(static::$container->get(SerializerInterface::class), $kernel);
     }
 
     private function createHttpException(string $message, int $statusCode): Throwable


### PR DESCRIPTION
Tickets:

- https://oat-sa.atlassian.net/browse/RO-64
- https://oat-sa.atlassian.net/browse/RO-65

Goal of this PR is to enable BooleanArgumentFlag rule of PHP Mess detector in CI pipeline.