### PR TITLE
[RO-80] Added basic auth for webhook endpoint

### DIFF
--- a/.env
+++ b/.env
@@ -78,3 +78,6 @@ BLACKFIRE_SERVER_TOKEN=<your_backfire_server_token>
 # MESSENGER_TRANSPORT_DSN=amqp://guest:guest@localhost:5672/%2f/messages
 # MESSENGER_TRANSPORT_DSN=redis://localhost:6379/messages
 ###< symfony/messenger ###
+
+WEBHOOK_USERNAME=webhook
+WEBHOOK_PASSWORD=cCVMxdX8hfctDefk

--- a/.env
+++ b/.env
@@ -79,5 +79,5 @@ BLACKFIRE_SERVER_TOKEN=<your_backfire_server_token>
 # MESSENGER_TRANSPORT_DSN=redis://localhost:6379/messages
 ###< symfony/messenger ###
 
-WEBHOOK_USERNAME=webhook
-WEBHOOK_PASSWORD=cCVMxdX8hfctDefk
+BASIC_AUTH_USERNAME=webhook
+BASIC_AUTH_PASSWORD=cCVMxdX8hfctDefk

--- a/.env
+++ b/.env
@@ -79,5 +79,5 @@ BLACKFIRE_SERVER_TOKEN=<your_backfire_server_token>
 # MESSENGER_TRANSPORT_DSN=redis://localhost:6379/messages
 ###< symfony/messenger ###
 
-BASIC_AUTH_USERNAME=webhook
-BASIC_AUTH_PASSWORD=cCVMxdX8hfctDefk
+WEBHOOK_BASIC_AUTH_USERNAME=webhook
+WEBHOOK_BASIC_AUTH_PASSWORD=cCVMxdX8hfctDefk

--- a/.env.docker
+++ b/.env.docker
@@ -69,5 +69,5 @@ BLACKFIRE_SERVER_ID=<your_backfire_id>
 BLACKFIRE_SERVER_TOKEN=<your_backfire_secret>
 ###< blackfire ###
 
-WEBHOOK_USERNAME=webhook
-WEBHOOK_PASSWORD=cCVMxdX8hfctDefk
+BASIC_AUTH_USERNAME=webhook
+BASIC_AUTH_PASSWORD=cCVMxdX8hfctDefk

--- a/.env.docker
+++ b/.env.docker
@@ -68,3 +68,6 @@ LTI1P3_TOOL_JWKS_URL=http://demo_lti1p3_nginx/lti1p3/.well-known/jwks/toolSet.js
 BLACKFIRE_SERVER_ID=<your_backfire_id>
 BLACKFIRE_SERVER_TOKEN=<your_backfire_secret>
 ###< blackfire ###
+
+WEBHOOK_USERNAME=webhook
+WEBHOOK_PASSWORD=cCVMxdX8hfctDefk

--- a/.env.docker
+++ b/.env.docker
@@ -69,5 +69,5 @@ BLACKFIRE_SERVER_ID=<your_backfire_id>
 BLACKFIRE_SERVER_TOKEN=<your_backfire_secret>
 ###< blackfire ###
 
-BASIC_AUTH_USERNAME=webhook
-BASIC_AUTH_PASSWORD=cCVMxdX8hfctDefk
+WEBHOOK_BASIC_AUTH_USERNAME=webhook
+WEBHOOK_BASIC_AUTH_PASSWORD=cCVMxdX8hfctDefk

--- a/.env.test
+++ b/.env.test
@@ -72,5 +72,5 @@ CORS_ALLOW_ORIGIN='^https?://localhost(:[0-9]+)?$'
 MESSENGER_TRANSPORT_DSN=in-memory://
 ###< symfony/messenger ###
 
-WEBHOOK_USERNAME=testUsername
-WEBHOOK_PASSWORD=testPassword
+BASIC_AUTH_USERNAME=testUsername
+BASIC_AUTH_PASSWORD=testPassword

--- a/.env.test
+++ b/.env.test
@@ -71,3 +71,6 @@ CORS_ALLOW_ORIGIN='^https?://localhost(:[0-9]+)?$'
 # Choose one of the transports below
 MESSENGER_TRANSPORT_DSN=in-memory://
 ###< symfony/messenger ###
+
+WEBHOOK_USERNAME=testUsername
+WEBHOOK_PASSWORD=testPassword

--- a/.env.test
+++ b/.env.test
@@ -72,5 +72,5 @@ CORS_ALLOW_ORIGIN='^https?://localhost(:[0-9]+)?$'
 MESSENGER_TRANSPORT_DSN=in-memory://
 ###< symfony/messenger ###
 
-BASIC_AUTH_USERNAME=testUsername
-BASIC_AUTH_PASSWORD=testPassword
+WEBHOOK_BASIC_AUTH_USERNAME=testUsername
+WEBHOOK_BASIC_AUTH_PASSWORD=testPassword

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 - Added `LTI_VERSION` environment variable to control version we are working (1.1.1 or 1.3.0).
 - Added `CACHE_TTL_LINE_ITEM` environment variable.
 - Added environment variables specific for [LTI 1.3](docs/devops-documentation.md).
-- Added `BASIC_AUTH_USERNAME` and `BASIC_AUTH_PASSWORD` environment variables.
+- Added `WEBHOOK_BASIC_AUTH_USERNAME` and `WEBHOOK_BASIC_AUTH_PASSWORD` environment variables.
 - Added possibility to profile CLI commands and HTTP calls with [Blackfire](docs/blackfire.md).
 - Added static code analysis with PHPStan, PHP Mess Detector and PHP CodeSniffer to pull request CI pipeline.
 - Added possibility to update line items via WebHook Endpoint: `/v1/web-hooks/update-line-items`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@
 - Added possibility to process a `basic outcome replaceResult` request using LTI 1.3 flow.
 - Added `LTI_VERSION` environment variable to control version we are working (1.1.1 or 1.3.0).
 - Added `CACHE_TTL_LINE_ITEM` environment.
-- Added environment variables specific for [LTI 1.3](docs/devops-documentation.md) 
+- Added environment variables specific for [LTI 1.3](docs/devops-documentation.md).
+- Added `WEBHOOK_USERNAME` and `WEBHOOK_PASSWORD` environment variables for webhook endpoint authentication.
 - Added possibility to profile CLI commands and HTTP calls with [Blackfire](docs/blackfire.md).
 - Added static code analysis with PHPStan, PHP Mess Detector and PHP CodeSniffer to pull request CI pipeline.
 - Added possibility to update line items via WebHook Endpoint: `/v1/web-hooks/update-line-items`
@@ -35,6 +36,7 @@
 - Application namespace has been changed from `App\` to `OAT\SimpleRoster\`.
 - Changed `APP_ROUTE_PREFIX` variable to exclude API version from it. Corresponding changes made to the `routes.yaml`/`security.yaml`
 - Renamed `UpdateLtiOutcomeAction` to `UpdateLti1p1OutcomeAction` for consistency.
+- Changed security settings to add basic authentication to webhook endpoint.
 
 ### Removed
 - Removed `roster:ingest` command.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,9 @@
 - Added possibility to launch assignments with [LTI 1.3](http://www.imsglobal.org/spec/lti/v1p3/).
 - Added possibility to process a `basic outcome replaceResult` request using LTI 1.3 flow.
 - Added `LTI_VERSION` environment variable to control version we are working (1.1.1 or 1.3.0).
-- Added `CACHE_TTL_LINE_ITEM` environment.
+- Added `CACHE_TTL_LINE_ITEM` environment variable.
 - Added environment variables specific for [LTI 1.3](docs/devops-documentation.md).
-- Added `WEBHOOK_USERNAME` and `WEBHOOK_PASSWORD` environment variables for webhook endpoint authentication.
+- Added `BASIC_AUTH_USERNAME` and `BASIC_AUTH_PASSWORD` environment variables.
 - Added possibility to profile CLI commands and HTTP calls with [Blackfire](docs/blackfire.md).
 - Added static code analysis with PHPStan, PHP Mess Detector and PHP CodeSniffer to pull request CI pipeline.
 - Added possibility to update line items via WebHook Endpoint: `/v1/web-hooks/update-line-items`
@@ -36,7 +36,7 @@
 - Application namespace has been changed from `App\` to `OAT\SimpleRoster\`.
 - Changed `APP_ROUTE_PREFIX` variable to exclude API version from it. Corresponding changes made to the `routes.yaml`/`security.yaml`
 - Renamed `UpdateLtiOutcomeAction` to `UpdateLti1p1OutcomeAction` for consistency.
-- Changed security settings to add basic authentication to webhook endpoint.
+- Changed security settings to use basic authentication on webhook endpoint.
 
 ### Removed
 - Removed `roster:ingest` command.

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -12,8 +12,8 @@ security:
         basic_auth_provider:
             memory:
                 users:
-                    '%env(BASIC_AUTH_USERNAME)%':
-                        password: '%env(BASIC_AUTH_PASSWORD)%'
+                    '%env(WEBHOOK_BASIC_AUTH_USERNAME)%':
+                        password: '%env(WEBHOOK_BASIC_AUTH_PASSWORD)%'
                         roles:
                             - ROLE_USER
 

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -9,11 +9,11 @@ security:
     providers:
         app_user_provider:
             id: OAT\SimpleRoster\Security\Provider\UserProvider
-        webhook_user_provider:
+        basic_auth_provider:
             memory:
                 users:
-                    '%env(WEBHOOK_USERNAME)%':
-                        password: '%env(WEBHOOK_PASSWORD)%'
+                    '%env(BASIC_AUTH_USERNAME)%':
+                        password: '%env(BASIC_AUTH_PASSWORD)%'
                         roles:
                             - ROLE_USER
 
@@ -42,7 +42,7 @@ security:
         webhooks:
             pattern: '^%app.route_prefix%/v1/web-hooks'
             stateless: true
-            provider: webhook_user_provider
+            provider: basic_auth_provider
             http_basic:
                 realm: 'Secured Webhooks'
 

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -1,6 +1,7 @@
 security:
     # https://symfony.com/doc/current/security.html#where-do-users-come-from-user-providers
     encoders:
+        Symfony\Component\Security\Core\User\User: plaintext
         OAT\SimpleRoster\Entity\User:
             algorithm: auto
             memory_cost: 1024
@@ -8,6 +9,13 @@ security:
     providers:
         app_user_provider:
             id: OAT\SimpleRoster\Security\Provider\UserProvider
+        webhook_user_provider:
+            memory:
+                users:
+                    webhook:
+                        password: 'pass'
+                        roles:
+                            - ROLE_USER
 
     firewalls:
         dev:
@@ -17,6 +25,7 @@ security:
         api_key:
             anonymous: ~
             pattern: '^%app.route_prefix%/v1/bulk'
+            provider: app_user_provider
             guard:
                 authenticators:
                     - OAT\SimpleRoster\Security\Authenticator\ApiKeyAuthenticator
@@ -25,13 +34,22 @@ security:
         lti1p3:
             pattern: '^%app.route_prefix%/v1/lti1p3/outcome'
             stateless: true
+            provider: app_user_provider
             lti1p3_service:
                 scopes:
                     - 'https://purl.imsglobal.org/spec/lti-bo/scope/basicoutcome'
 
+        webhooks:
+            pattern: '^%app.route_prefix%/v1/web-hooks'
+            stateless: true
+            provider: webhook_user_provider
+            http_basic:
+                realm: 'Secured Webhooks'
+
         api:
             anonymous: ~
             pattern: '^%app.route_prefix%/v1'
+            provider: app_user_provider
             logout:
                 path: logout
                 success_handler: OAT\SimpleRoster\Security\Handler\LogoutSuccessHandler
@@ -49,5 +67,5 @@ security:
         - { path: '^%app.route_prefix%/v1/healthcheck', roles: IS_AUTHENTICATED_ANONYMOUSLY }
         - { path: '^%app.route_prefix%/v1/lti1p1/outcome', roles: IS_AUTHENTICATED_ANONYMOUSLY }
         - { path: '^%app.route_prefix%/v1/lti1p3/outcome', roles: IS_AUTHENTICATED_ANONYMOUSLY }
-        - { path: '^%app.route_prefix%/v1/web-hooks/update-line-items', roles: IS_AUTHENTICATED_ANONYMOUSLY }
+        - { path: '^%app.route_prefix%/v1/web-hooks/update-line-items', roles: ROLE_USER }
         - { path: '^%app.route_prefix%/v1', roles: ROLE_USER }

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -12,8 +12,8 @@ security:
         webhook_user_provider:
             memory:
                 users:
-                    webhook:
-                        password: 'pass'
+                    '%env(WEBHOOK_USERNAME)%':
+                        password: '%env(WEBHOOK_PASSWORD)%'
                         roles:
                             - ROLE_USER
 

--- a/docs/devops-documentation.md
+++ b/docs/devops-documentation.md
@@ -38,8 +38,8 @@ The main configuration file is `.env`, located in root folder.
 | CACHE_TTL_LTI_INSTANCES | Cache TTL (in seconds) for LTI instance list [default: `3600`] |
 | CORS_ALLOW_ORIGIN | Allowed CORS origin |
 | ASSIGNMENT_STATE_INTERVAL_THRESHOLD | Threshold for assignment garbage collection [default: `P1D`] |
-| WEBHOOK_USERNAME | Webhook endpoint username |
-| WEBHOOK_PASSWORD | Webhook endpoint password |
+| BASIC_AUTH_USERNAME | Basic auth username |
+| BASIC_AUTH_PASSWORD | basic auth password |
        
 #### LTI related environment variables
 

--- a/docs/devops-documentation.md
+++ b/docs/devops-documentation.md
@@ -38,8 +38,8 @@ The main configuration file is `.env`, located in root folder.
 | CACHE_TTL_LTI_INSTANCES | Cache TTL (in seconds) for LTI instance list [default: `3600`] |
 | CORS_ALLOW_ORIGIN | Allowed CORS origin |
 | ASSIGNMENT_STATE_INTERVAL_THRESHOLD | Threshold for assignment garbage collection [default: `P1D`] |
-| BASIC_AUTH_USERNAME | Basic auth username |
-| BASIC_AUTH_PASSWORD | basic auth password |
+| WEBHOOK_BASIC_AUTH_USERNAME | Basic auth username for webhook |
+| WEBHOOK_BASIC_AUTH_PASSWORD | basic auth password for webhook |
        
 #### LTI related environment variables
 

--- a/docs/devops-documentation.md
+++ b/docs/devops-documentation.md
@@ -38,6 +38,8 @@ The main configuration file is `.env`, located in root folder.
 | CACHE_TTL_LTI_INSTANCES | Cache TTL (in seconds) for LTI instance list [default: `3600`] |
 | CORS_ALLOW_ORIGIN | Allowed CORS origin |
 | ASSIGNMENT_STATE_INTERVAL_THRESHOLD | Threshold for assignment garbage collection [default: `P1D`] |
+| WEBHOOK_USERNAME | Webhook endpoint username |
+| WEBHOOK_PASSWORD | Webhook endpoint password |
        
 #### LTI related environment variables
 

--- a/docs/features/update-line-items-webhook.md
+++ b/docs/features/update-line-items-webhook.md
@@ -17,6 +17,7 @@ Here you can find an example about how to update the line-item via curl command:
 ```shell script
 curl --location --request POST 'http://simple-roster.docker.localhost/api/v1/web-hooks/update-line-items' \
 --header 'Content-Type: application/json' \
+--header 'Authorization: Basic d2ViaG9vazpjQ1ZNeGRYOGhmY3REZWZr' \
 --data-raw '{
 	"source":"https://someinstance.taocloud.org/",
 	"events":[
@@ -32,6 +33,11 @@ curl --location --request POST 'http://simple-roster.docker.localhost/api/v1/web
 	]
 }'
 ```
+
+#### Authentication
+
+To use this endpoint, basic authentication should be used based on `WEBHOOK_USERNAME` and `WEBHOOK_USERNAME` configured 
+on environment settings.
 
 #### Attribute Descriptions
 

--- a/docs/features/update-line-items-webhook.md
+++ b/docs/features/update-line-items-webhook.md
@@ -36,8 +36,8 @@ curl --location --request POST 'http://simple-roster.docker.localhost/api/v1/web
 
 #### Authentication
 
-To use this endpoint, basic authentication should be used based on `WEBHOOK_USERNAME` and `WEBHOOK_USERNAME` configured 
-on environment settings.
+To use this endpoint, the `Authorization` header should be defined as the sample above.
+The credentials should match the ones defined on `BASIC_AUTH_USERNAME` and `BASIC_AUTH_USERNAME` environment variables.
 
 #### Attribute Descriptions
 

--- a/openapi/api_v1.yml
+++ b/openapi/api_v1.yml
@@ -272,14 +272,8 @@ paths:
             summary: Notify Api about new Delivery URIs to be updated
             tags:
                 - web-hook
-            security: []
-            parameters:
-                -   name: Authorization
-                    description: OAuth authorization header, including OAuth parameters
-                    in: header
-                    schema:
-                        type: string
-                        example: To be Defined
+            security:
+                -   basicAuth: [ ]
             requestBody:
                 required: true
                 content:
@@ -310,6 +304,9 @@ components:
             type: http
             scheme: bearer
             bearerFormat: JWT
+        basicAuth:
+            type: http
+            scheme: basic
     schemas:
         Assignment:
             type: object

--- a/tests/Functional/Action/WebHook/UpdateLineItemsWebhookActionTest.php
+++ b/tests/Functional/Action/WebHook/UpdateLineItemsWebhookActionTest.php
@@ -68,7 +68,7 @@ class UpdateLineItemsWebhookActionTest extends WebTestCase
         $this->setUpTestLogHandler();
     }
 
-    public function testItReturns401IfNotAuthenticated(): void
+    public function testItReturns401IfNoCredentialsInformed(): void
     {
         $this->kernelBrowser->request(
             Request::METHOD_POST,
@@ -82,7 +82,7 @@ class UpdateLineItemsWebhookActionTest extends WebTestCase
         self::assertEquals(Response::HTTP_UNAUTHORIZED, $this->kernelBrowser->getResponse()->getStatusCode());
     }
 
-    public function testItReturns401IfWrongAuthentication(): void
+    public function testItReturns401IfWrongCredentialsInformed(): void
     {
         $this->kernelBrowser->request(
             Request::METHOD_POST,

--- a/tests/Functional/Action/WebHook/UpdateLineItemsWebhookActionTest.php
+++ b/tests/Functional/Action/WebHook/UpdateLineItemsWebhookActionTest.php
@@ -68,6 +68,37 @@ class UpdateLineItemsWebhookActionTest extends WebTestCase
         $this->setUpTestLogHandler();
     }
 
+    public function testItReturns401IfNotAuthenticated(): void
+    {
+        $this->kernelBrowser->request(
+            Request::METHOD_POST,
+            '/api/v1/web-hooks/update-line-items',
+            [],
+            [],
+            [],
+            ''
+        );
+
+        self::assertEquals(Response::HTTP_UNAUTHORIZED, $this->kernelBrowser->getResponse()->getStatusCode());
+    }
+
+    public function testItReturns401IfWrongAuthentication(): void
+    {
+        $this->kernelBrowser->request(
+            Request::METHOD_POST,
+            '/api/v1/web-hooks/update-line-items',
+            [],
+            [],
+            [
+                'PHP_AUTH_USER' => 'wrongUsername',
+                'PHP_AUTH_PW' => 'wrongPassword'
+            ],
+            ''
+        );
+
+        self::assertEquals(Response::HTTP_UNAUTHORIZED, $this->kernelBrowser->getResponse()->getStatusCode());
+    }
+
     /**
      * @dataProvider provideWrongRequestBodies
      *
@@ -82,7 +113,10 @@ class UpdateLineItemsWebhookActionTest extends WebTestCase
             '/api/v1/web-hooks/update-line-items',
             [],
             [],
-            [],
+            [
+                'PHP_AUTH_USER' => 'testUsername',
+                'PHP_AUTH_PW' => 'testPassword'
+            ],
             $requestBody
         );
 
@@ -108,7 +142,10 @@ class UpdateLineItemsWebhookActionTest extends WebTestCase
             '/api/v1/web-hooks/update-line-items',
             [],
             [],
-            [],
+            [
+                'PHP_AUTH_USER' => 'testUsername',
+                'PHP_AUTH_PW' => 'testPassword'
+            ],
             (string)json_encode($this->getSuccessRequestBody())
         );
 
@@ -185,7 +222,10 @@ class UpdateLineItemsWebhookActionTest extends WebTestCase
             '/api/v1/web-hooks/update-line-items',
             [],
             [],
-            [],
+            [
+                'PHP_AUTH_USER' => 'testUsername',
+                'PHP_AUTH_PW' => 'testPassword'
+            ],
             (string)json_encode($this->getRequestBodyUnknownEvent())
         );
 


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/RO-80

### Added
- Added `WEBHOOK_BASIC_AUTH_USERNAME` and `WEBHOOK_BASIC_AUTH_PASSWORD` environment variables.

### Changed 
- Changed security settings to add basic authentication to webhook endpoint.
