### PR TITLE
[RO-236] Fixed missing cache invalidation at bulk assignment creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.0.4 - 2021-02-25
+
+### Fixed
+- Fixed missing cache invalidation when creating new assignments through the bulk create assignments API endpoint.
+
 ## 2.0.3 - 2021-02-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 >REST back-end service intending to mimic a simplified version of OneRoster IMS specification.
 
-![current version](https://img.shields.io/badge/version-2.0.3-green.svg)
+![current version](https://img.shields.io/badge/version-2.0.4-green.svg)
 [![License: GPL v2](https://img.shields.io/badge/License-GPL%20v2-blue.svg)](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html)
 ![coverage](https://img.shields.io/badge/coverage-100%25-green.svg)
 

--- a/src/Bulk/Result/BulkResult.php
+++ b/src/Bulk/Result/BulkResult.php
@@ -38,6 +38,21 @@ class BulkResult implements JsonSerializable
         return $this->addBulkOperationResult($operation, true);
     }
 
+    /**
+     * @return string[]
+     */
+    public function getSuccessfulBulkOperationIdentifiers(): array
+    {
+        return array_keys(
+            array_filter(
+                $this->results,
+                static function (bool $result): bool {
+                    return $result === true;
+                }
+            )
+        );
+    }
+
     public function addBulkOperationFailure(BulkOperation $operation): self
     {
         $this->failuresCount++;

--- a/src/Model/UsernameCollection.php
+++ b/src/Model/UsernameCollection.php
@@ -29,7 +29,12 @@ use IteratorAggregate;
 class UsernameCollection implements Countable, IteratorAggregate
 {
     /** @var string[] */
-    private $collection = [];
+    private $collection;
+
+    public function __construct(string ...$usernames)
+    {
+        $this->collection = $usernames;
+    }
 
     public function add(string $username): self
     {

--- a/tests/Unit/Bulk/Result/BulkResultTest.php
+++ b/tests/Unit/Bulk/Result/BulkResultTest.php
@@ -77,4 +77,25 @@ class BulkResultTest extends TestCase
             $subject->jsonSerialize()
         );
     }
+
+    public function testItReturnsSuccessfulBulkOperationIdentifiers(): void
+    {
+        $subject = new BulkResult();
+
+        $operation1 = new BulkOperation('identifier1', BulkOperation::TYPE_UPDATE);
+        $operation2 = new BulkOperation('identifier2', BulkOperation::TYPE_CREATE);
+        $operation3 = new BulkOperation('identifier3', BulkOperation::TYPE_CREATE);
+        $operation4 = new BulkOperation('identifier4', BulkOperation::TYPE_UPDATE);
+
+        $subject
+            ->addBulkOperationSuccess($operation1)
+            ->addBulkOperationSuccess($operation3)
+            ->addBulkOperationFailure($operation2)
+            ->addBulkOperationFailure($operation4);
+
+        self::assertSame(
+            ['identifier1', 'identifier3'],
+            $subject->getSuccessfulBulkOperationIdentifiers()
+        );
+    }
 }


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/RO-236

### Fixed
- Fixed missing cache invalidation when creating new assignments through the bulk create assignments API endpoint.
