### PR TITLE
Release/release v2.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 2.0.5 - 2021-03-01
+- renamed event payload attribute name from deliveryURI to remoteDeliveryId
 
 ## 2.0.4 - 2021-02-25
 

--- a/docs/features/update-line-items-webhook.md
+++ b/docs/features/update-line-items-webhook.md
@@ -36,7 +36,7 @@ curl --location --request POST 'http://simple-roster.docker.localhost/api/v1/web
 			"triggeredTimestamp":1565602390,
 			"eventData":{
 				"alias":"line-item-slug",
-				"deliveryURI":"https://tao.platform/ontologies/tao.rdf#delivery-uri"
+				"remoteDeliveryId":"https://tao.platform/ontologies/tao.rdf#delivery-uri"
 			}
 		}
 	]
@@ -49,13 +49,13 @@ To use this endpoint, the `Authorization` header should be defined as the sample
 
 #### Attribute Descriptions
 
-| Attribute             | Description                                                                                                                                                                                                      |
-| ----------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| eventId               | The event identifier. The format is described in the [WebHook Payload Schema Definition](#webhook-schema-definition). It is used by the Simple Roster only to return it in the webhook response.                 |
-| eventName             | The name of the event. Only `RemoteDeliveryPublicationFinished` will be handled by Simple Roster. Any other events will be ignored.                                                                              |
-| triggeredTimestamp    | A timestamp that represents when the event happened. In case of duplicate events, Simple Roster will assume the latter based on this attribute. The other events will be ignored.                                |
-| eventData.alias       | The delivery URI alias for the new publication. This value must match the slug in the line items that need to be updated. If the line items are not found, the event is not accepted and is considered an error. |
-| eventData.deliveryURI | The Delivery URI of the new publication. In case the alias match with the line items slug, this value will replace the line items URI.                                                                           |
+| Attribute                  | Description                                                                                                                                                                                                      |
+| ---------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| eventId                    | The event identifier. The format is described in the [WebHook Payload Schema Definition](#webhook-schema-definition). It is used by the Simple Roster only to return it in the webhook response.                 |
+| eventName                  | The name of the event. Only `RemoteDeliveryPublicationFinished` will be handled by Simple Roster. Any other events will be ignored.                                                                              |
+| triggeredTimestamp         | A timestamp that represents when the event happened. In case of duplicate events, Simple Roster will assume the latter based on this attribute. The other events will be ignored.                                |
+| eventData.alias            | The delivery URI alias for the new publication. This value must match the slug in the line items that need to be updated. If the line items are not found, the event is not accepted and is considered an error. |
+| eventData.remoteDeliveryId | The Delivery URI of the new publication. In case the alias match with the line items slug, this value will replace the line items URI.                                                                           |
 
 ### Endpoint Descriptions
 

--- a/openapi/api_v1.yml
+++ b/openapi/api_v1.yml
@@ -418,11 +418,11 @@ components:
                                     alias:
                                         type: string
                                         description: This data should match with the line item slug on the simple roster context
-                                    deliveryURI:
+                                    remoteDeliveryId:
                                         type: string
                                         description: Based on the match between alias and slug, this field will be the new uri on the matched line item
                                 required:
-                                    - deliveryURI
+                                    - remoteDeliveryId
                         required:
                             - eventId
                             - eventName

--- a/src/Request/ParamConverter/UpdateLineItemWebHookParamConverter.php
+++ b/src/Request/ParamConverter/UpdateLineItemWebHookParamConverter.php
@@ -59,7 +59,7 @@ class UpdateLineItemWebHookParamConverter implements ParamConverterInterface
             $events[] = new UpdateLineItemDto(
                 (string)$event['eventId'],
                 (string)$event['eventName'],
-                (string)$event['eventData']['deliveryURI'],
+                (string)$event['eventData']['remoteDeliveryId'],
                 (new DateTimeImmutable())->setTimestamp($event['triggeredTimestamp']),
                 $event['eventData']['alias'] ?? null
             );

--- a/src/Request/Validator/UpdateLineItemValidator.php
+++ b/src/Request/Validator/UpdateLineItemValidator.php
@@ -98,7 +98,7 @@ class UpdateLineItemValidator
                                                                     new Assert\Type('string'),
                                                                 ],
                                                             ),
-                                                            "deliveryURI" => new Assert\Type('string'),
+                                                            "remoteDeliveryId" => new Assert\Type('string'),
                                                         ],
                                                         'allowExtraFields' => true,
                                                     ],

--- a/tests/Functional/Action/WebHook/UpdateLineItemsWebhookActionTest.php
+++ b/tests/Functional/Action/WebHook/UpdateLineItemsWebhookActionTest.php
@@ -252,7 +252,8 @@ class UpdateLineItemsWebhookActionTest extends WebTestCase
      */
     public function provideWrongRequestBodies(): array
     {
-        $missingDeliveryUri = 'Invalid Request Body: [events][0][eventData][deliveryURI] -> This field is missing.';
+        $missingRemoteDeliveryId = 'Invalid Request Body: '
+            . '[events][0][eventData][remoteDeliveryId] -> This field is missing.';
 
         $invalidAliasType = 'Invalid Request Body: [events][0][eventName] -> This field is missing.'
             . ' [events][0][eventData][alias] -> This value should be of type string.';
@@ -279,7 +280,7 @@ class UpdateLineItemsWebhookActionTest extends WebTestCase
                                     'triggeredTimestamp' => 1565602371,
                                     'eventData' => [
                                         'alias' => 'qti-interactions-delivery',
-                                        'deliveryURI' => 'https://docker.localhost/ontologies/tao.rdf#FFF',
+                                        'remoteDeliveryId' => 'https://docker.localhost/ontologies/tao.rdf#FFF',
                                     ],
                                 ],
                             ],
@@ -298,7 +299,7 @@ class UpdateLineItemsWebhookActionTest extends WebTestCase
                                 'triggeredTimestamp' => 1565602371,
                                 'eventData' => [
                                     'alias' => 'qti-interactions-delivery',
-                                    'deliveryURI' => 'https://docker.localhost/ontologies/tao.rdf#FFF',
+                                    'remoteDeliveryId' => 'https://docker.localhost/ontologies/tao.rdf#FFF',
                                 ],
                             ],
                         ],
@@ -316,7 +317,7 @@ class UpdateLineItemsWebhookActionTest extends WebTestCase
                                 'eventName' => 'RemoteDeliveryPublicationFinishesssd',
                                 'eventData' => [
                                     'alias' => 'qti-interactions-delivery',
-                                    'deliveryURI' => 'https://docker.localhost/ontologies/tao.rdf#FFF',
+                                    'remoteDeliveryId' => 'https://docker.localhost/ontologies/tao.rdf#FFF',
                                 ],
                             ],
                         ],
@@ -324,7 +325,7 @@ class UpdateLineItemsWebhookActionTest extends WebTestCase
                 ),
                 'expectedMessage' => 'Invalid Request Body: [events][0][triggeredTimestamp] -> This field is missing.',
             ],
-            'IncompleteEventDeliveryUri' => [
+            'IncompleteEventRemoteDeliveryId' => [
                 'requestBody' => json_encode(
                     [
                         'source' => 'https://someinstance.taocloud.org/',
@@ -340,7 +341,7 @@ class UpdateLineItemsWebhookActionTest extends WebTestCase
                         ],
                     ]
                 ),
-                'expectedMessage' => $missingDeliveryUri,
+                'expectedMessage' => $missingRemoteDeliveryId,
             ],
             'WrongAliasType' => [
                 'requestBody' => json_encode(
@@ -352,7 +353,7 @@ class UpdateLineItemsWebhookActionTest extends WebTestCase
                                 'triggeredTimestamp' => 1565602371,
                                 'eventData' => [
                                     'alias' => 123,
-                                    'deliveryURI' => 'https://docker.localhost/ontologies/tao.rdf#FFF',
+                                    'remoteDeliveryId' => 'https://docker.localhost/ontologies/tao.rdf#FFF',
                                 ],
                             ],
                         ],
@@ -393,7 +394,7 @@ class UpdateLineItemsWebhookActionTest extends WebTestCase
                     'triggeredTimestamp' => 1565602371,
                     'eventData' => [
                         'alias' => 'qti-interactions-delivery',
-                        'deliveryURI' => 'https://docker.localhost/ontologies/tao.rdf#FFF',
+                        'remoteDeliveryId' => 'https://docker.localhost/ontologies/tao.rdf#FFF',
                         'withExtraFields' => true,
                     ],
                     'withExtraFields' => true,
@@ -404,7 +405,7 @@ class UpdateLineItemsWebhookActionTest extends WebTestCase
                     'triggeredTimestamp' => 1565602371,
                     'eventData' => [
                         'alias' => 'wrong-alias',
-                        'deliveryURI' => 'https://docker.localhost/ontologies/tao.rdf#FFF',
+                        'remoteDeliveryId' => 'https://docker.localhost/ontologies/tao.rdf#FFF',
                     ],
                 ],
                 [
@@ -413,7 +414,7 @@ class UpdateLineItemsWebhookActionTest extends WebTestCase
                     'triggeredTimestamp' => 1565602390,
                     'eventData' => [
                         'alias' => 'lineItemSlug',
-                        'deliveryURI' => 'https://docker.localhost/ontologies/tao.rdf#RightOne',
+                        'remoteDeliveryId' => 'https://docker.localhost/ontologies/tao.rdf#RightOne',
                     ],
                 ],
                 [
@@ -422,7 +423,7 @@ class UpdateLineItemsWebhookActionTest extends WebTestCase
                     'triggeredTimestamp' => 1565602380,
                     'eventData' => [
                         'alias' => 'lineItemSlug',
-                        'deliveryURI' => 'https://docker.localhost/ontologies/tao.rdf#FFF',
+                        'remoteDeliveryId' => 'https://docker.localhost/ontologies/tao.rdf#FFF',
                     ],
                 ],
             ],
@@ -440,7 +441,7 @@ class UpdateLineItemsWebhookActionTest extends WebTestCase
                     'triggeredTimestamp' => 1565602371,
                     'eventData' => [
                         'alias' => 'qti-interactions-delivery',
-                        'deliveryURI' => 'https://docker.localhost/ontologies/tao.rdf#FFF',
+                        'remoteDeliveryId' => 'https://docker.localhost/ontologies/tao.rdf#FFF',
                     ],
                 ],
             ],

--- a/tests/Unit/Request/ParamConverter/UpdateLineItemWebHookParamConverterTest.php
+++ b/tests/Unit/Request/ParamConverter/UpdateLineItemWebHookParamConverterTest.php
@@ -77,7 +77,7 @@ class UpdateLineItemWebHookParamConverterTest extends TestCase
                             "triggeredTimestamp":1565602390,
                             "eventData":{
                                 "alias":"qti-interactions-delivery",
-                                "deliveryURI":"https://tao.instance/ontologies/tao.rdf#kkkkzk"
+                                "remoteDeliveryId":"https://tao.instance/ontologies/tao.rdf#kkkkzk"
                             }
                         }
                     ]


### PR DESCRIPTION
# Fixed

* renamed expected webhook payload event attribute from deliveryURI to remoteDeliveryId
