### PR TITLE
[RO-238] Tao webhook - rename event name value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- Renamed webhook event name from `RemoteDeliveryPublicationFinished` to `oat\\taoPublishing\\model\\publishing\\event\\RemoteDeliveryCreatedEvent`.
+
 ## 2.0.5 - 2021-03-03
 
 ### Fixed

--- a/docs/features/update-line-items-webhook.md
+++ b/docs/features/update-line-items-webhook.md
@@ -32,7 +32,7 @@ curl --location --request POST 'http://simple-roster.docker.localhost/api/v1/web
 	"events":[
         {
 			"eventId":"52a3de8dd0f270fd193f9f4bff05232c",
-			"eventName":"RemoteDeliveryPublicationFinished",
+			"eventName":"oat\\taoPublishing\\model\\publishing\\event\\RemoteDeliveryCreatedEvent",
 			"triggeredTimestamp":1565602390,
 			"eventData":{
 				"alias":"line-item-slug",
@@ -52,7 +52,7 @@ To use this endpoint, the `Authorization` header should be defined as the sample
 | Attribute                  | Description                                                                                                                                                                                                      |
 | ---------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | eventId                    | The event identifier. The format is described in the [WebHook Payload Schema Definition](#webhook-schema-definition). It is used by the Simple Roster only to return it in the webhook response.                 |
-| eventName                  | The name of the event. Only `RemoteDeliveryPublicationFinished` will be handled by Simple Roster. Any other events will be ignored.                                                                              |
+| eventName                  | The name of the event. Only `oat\\taoPublishing\\model\\publishing\\event\\RemoteDeliveryCreatedEvent` will be handled by Simple Roster. Any other events will be ignored.                                       |
 | triggeredTimestamp         | A timestamp that represents when the event happened. In case of duplicate events, Simple Roster will assume the latter based on this attribute. The other events will be ignored.                                |
 | eventData.alias            | The delivery URI alias for the new publication. This value must match the slug in the line items that need to be updated. If the line items are not found, the event is not accepted and is considered an error. |
 | eventData.remoteDeliveryId | The Delivery URI of the new publication. In case the alias match with the line items slug, this value will replace the line items URI.                                                                           |

--- a/src/WebHook/UpdateLineItemDto.php
+++ b/src/WebHook/UpdateLineItemDto.php
@@ -31,7 +31,7 @@ class UpdateLineItemDto implements JsonSerializable
     public const STATUS_ERROR = 'error';
     public const STATUS_IGNORED = 'ignored';
 
-    public const NAME = 'RemoteDeliveryPublicationFinished';
+    public const NAME = 'oat\\taoPublishing\\model\\publishing\\event\\RemoteDeliveryCreatedEvent';
 
     /** @var string */
     private $id;

--- a/tests/Functional/Action/WebHook/UpdateLineItemsWebhookActionTest.php
+++ b/tests/Functional/Action/WebHook/UpdateLineItemsWebhookActionTest.php
@@ -401,7 +401,7 @@ class UpdateLineItemsWebhookActionTest extends WebTestCase
                 ],
                 [
                     'eventId' => '52a3de8dd0f270fd193f9f4bff05232f',
-                    'eventName' => 'RemoteDeliveryPublicationFinished',
+                    'eventName' => 'oat\\taoPublishing\\model\\publishing\\event\\RemoteDeliveryCreatedEvent',
                     'triggeredTimestamp' => 1565602371,
                     'eventData' => [
                         'alias' => 'wrong-alias',
@@ -410,7 +410,7 @@ class UpdateLineItemsWebhookActionTest extends WebTestCase
                 ],
                 [
                     'eventId' => 'lastDuplicatedEvent',
-                    'eventName' => 'RemoteDeliveryPublicationFinished',
+                    'eventName' => 'oat\\taoPublishing\\model\\publishing\\event\\RemoteDeliveryCreatedEvent',
                     'triggeredTimestamp' => 1565602390,
                     'eventData' => [
                         'alias' => 'lineItemSlug',
@@ -419,7 +419,7 @@ class UpdateLineItemsWebhookActionTest extends WebTestCase
                 ],
                 [
                     'eventId' => 'duplicated',
-                    'eventName' => 'RemoteDeliveryPublicationFinished',
+                    'eventName' => 'oat\\taoPublishing\\model\\publishing\\event\\RemoteDeliveryCreatedEvent',
                     'triggeredTimestamp' => 1565602380,
                     'eventData' => [
                         'alias' => 'lineItemSlug',

--- a/tests/Unit/Request/ParamConverter/UpdateLineItemWebHookParamConverterTest.php
+++ b/tests/Unit/Request/ParamConverter/UpdateLineItemWebHookParamConverterTest.php
@@ -68,12 +68,14 @@ class UpdateLineItemWebHookParamConverterTest extends TestCase
             Request::class
         );
 
+        $eventName = 'oat\\\\taoPublishing\\\\model\\\\publishing\\\\event\\\\RemoteDeliveryCreatedEvent';
+
         $payload = '{
                     "source":"https://someinstance.taocloud.org/",
                     "events":[
                         {
                             "eventId":"52a3de8dd0f270fd193f9f4bff05232c",
-                            "eventName":"RemoteDeliveryPublicationFinished",
+                            "eventName":"' . $eventName . '",
                             "triggeredTimestamp":1565602390,
                             "eventData":{
                                 "alias":"qti-interactions-delivery",
@@ -116,7 +118,10 @@ class UpdateLineItemWebHookParamConverterTest extends TestCase
         self::assertInstanceOf(UpdateLineItemDto::class, $updateLineItemDto);
 
         self::assertSame("52a3de8dd0f270fd193f9f4bff05232c", $updateLineItemDto->getId());
-        self::assertSame("RemoteDeliveryPublicationFinished", $updateLineItemDto->getName());
+        self::assertSame(
+            'oat\\taoPublishing\\model\\publishing\\event\\RemoteDeliveryCreatedEvent',
+            $updateLineItemDto->getName()
+        );
         self::assertSame(1565602390, $updateLineItemDto->getTriggeredTime()->getTimestamp());
         self::assertSame("qti-interactions-delivery", $updateLineItemDto->getSlug());
         self::assertSame(

--- a/tests/Unit/Webhook/Service/UpdateLineItemsServiceTest.php
+++ b/tests/Unit/Webhook/Service/UpdateLineItemsServiceTest.php
@@ -121,7 +121,7 @@ class UpdateLineItemsServiceTest extends TestCase
         $updateLineItemCollection = new UpdateLineItemCollection(
             new UpdateLineItemDto(
                 '52a3de8dd0f270fd193f9f4bff05232f',
-                'RemoteDeliveryPublicationFinished',
+                'oat\\taoPublishing\\model\\publishing\\event\\RemoteDeliveryCreatedEvent',
                 'https://tao.instance/ontologies/tao.rdf#i5fb5',
                 (new DateTimeImmutable())->setTimestamp(1565602371),
                 'qti-interactions-delivery'
@@ -175,14 +175,14 @@ class UpdateLineItemsServiceTest extends TestCase
         $updateLineItemCollection = new UpdateLineItemCollection(
             new UpdateLineItemDto(
                 '111',
-                'RemoteDeliveryPublicationFinished',
+                'oat\\taoPublishing\\model\\publishing\\event\\RemoteDeliveryCreatedEvent',
                 'https://tao.instance/ontologies/tao.rdf#i5fb5',
                 (new DateTimeImmutable())->setTimestamp(1565602380),
                 'qti-interactions-delivery'
             ),
             new UpdateLineItemDto(
                 '222',
-                'RemoteDeliveryPublicationFinished',
+                'oat\\taoPublishing\\model\\publishing\\event\\RemoteDeliveryCreatedEvent',
                 'https://tao.instance/ontologies/tao.rdf#duplicated',
                 (new DateTimeImmutable())->setTimestamp(1565602371),
                 'qti-interactions-delivery'
@@ -228,7 +228,7 @@ class UpdateLineItemsServiceTest extends TestCase
         $updateLineItemCollection = new UpdateLineItemCollection(
             new UpdateLineItemDto(
                 '52a3de8dd0f270fd193f9f4bff05232f',
-                'RemoteDeliveryPublicationFinished',
+                'oat\\taoPublishing\\model\\publishing\\event\\RemoteDeliveryCreatedEvent',
                 'https://tao.instance/ontologies/tao.rdf#i5fb5',
                 (new DateTimeImmutable())->setTimestamp(1565602371),
                 'qti-interactions-delivery'


### PR DESCRIPTION
# Introduction
This PR is intended to complete the issue https://oat-sa.atlassian.net/browse/RO-238.
During the integration tests between all the enviornments (Delivery, Authoring, Simple Roster, Test Taker Portal) we've noticed that the eventName is not the correct one. To make the endpoint work properly, we have to change the eventName to the correct one.

## Fixed
- Renamed webhook event name from `RemoteDeliveryPublicationFinished` to `oat\\taoPublishing\\model\\publishing\\event\\RemoteDeliveryCreatedEvent`.

Refs: #173, #198

## Current Situation
The line items will not be updated because unknow events are ignored

## After this PR
The line items will be updated by using the event name `oat\\taoPublishing\\model\\publishing\\event\\RemoteDeliveryCreatedEvent`