### PR TITLE
Release 2.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## 2.0.6 - 2021-03-12
 
 ### Fixed
 - Renamed webhook event name from `RemoteDeliveryPublicationFinished` to `oat\\taoPublishing\\model\\publishing\\event\\RemoteDeliveryCreatedEvent`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- Fixed [roster:modify-entity:line-item:change-dates](docs/cli/modify-entity-line-item-change-dates-command.md) command to allow proper use of timezone offset. 
+  We now convert the input date(s) to UTC before persisting it.
+
 ## 2.0.5 - 2021-03-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Renamed webhook event name from `RemoteDeliveryPublicationFinished` to `oat\\taoPublishing\\model\\publishing\\event\\RemoteDeliveryCreatedEvent`.
 - Fixed [roster:modify-entity:line-item:change-dates](docs/cli/modify-entity-line-item-change-dates-command.md) command to allow proper use of timezone offset. 
   We now convert the input date(s) to UTC before persisting it.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 >REST back-end service intending to mimic a simplified version of OneRoster IMS specification.
 
-![current version](https://img.shields.io/badge/version-2.0.5-green.svg)
+![current version](https://img.shields.io/badge/version-2.0.6-green.svg)
 [![License: GPL v2](https://img.shields.io/badge/License-GPL%20v2-blue.svg)](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html)
 ![coverage](https://img.shields.io/badge/coverage-100%25-green.svg)
 

--- a/docs/cli/modify-entity-line-item-change-dates-command.md
+++ b/docs/cli/modify-entity-line-item-change-dates-command.md
@@ -46,6 +46,10 @@ $ sudo -u www-data bin/console roster:modify-entity:line-item:change-dates -i 1,
 ```shell script
 $ sudo -u www-data bin/console roster:modify-entity:line-item:change-dates -s slug1,slug2,slug3 --start-date 2020-01-01T00:00:00+0000 --end-date 2020-01-05T00:00:00+0000 --force
 ```
+- Updating dates in a different timezone (UTC+1)
+```shell script
+$ sudo -u www-data bin/console roster:modify-entity:line-item:change-dates -s slug1,slug2,slug3 --start-date 2020-01-01T00:00:00+0100 --end-date 2020-01-05T00:00:00+0100 --force
+```
 - Nullifying dates of a line item by line item
 ```shell script
 //Nullifying start and end dates

--- a/docs/features/update-line-items-webhook.md
+++ b/docs/features/update-line-items-webhook.md
@@ -32,7 +32,7 @@ curl --location --request POST 'http://simple-roster.docker.localhost/api/v1/web
 	"events":[
         {
 			"eventId":"52a3de8dd0f270fd193f9f4bff05232c",
-			"eventName":"RemoteDeliveryPublicationFinished",
+			"eventName":"oat\\taoPublishing\\model\\publishing\\event\\RemoteDeliveryCreatedEvent",
 			"triggeredTimestamp":1565602390,
 			"eventData":{
 				"alias":"line-item-slug",
@@ -52,7 +52,7 @@ To use this endpoint, the `Authorization` header should be defined as the sample
 | Attribute                  | Description                                                                                                                                                                                                      |
 | ---------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | eventId                    | The event identifier. The format is described in the [WebHook Payload Schema Definition](#webhook-schema-definition). It is used by the Simple Roster only to return it in the webhook response.                 |
-| eventName                  | The name of the event. Only `RemoteDeliveryPublicationFinished` will be handled by Simple Roster. Any other events will be ignored.                                                                              |
+| eventName                  | The name of the event. Only `oat\\taoPublishing\\model\\publishing\\event\\RemoteDeliveryCreatedEvent` will be handled by Simple Roster. Any other events will be ignored.                                       |
 | triggeredTimestamp         | A timestamp that represents when the event happened. In case of duplicate events, Simple Roster will assume the latter based on this attribute. The other events will be ignored.                                |
 | eventData.alias            | The delivery URI alias for the new publication. This value must match the slug in the line items that need to be updated. If the line items are not found, the event is not accepted and is considered an error. |
 | eventData.remoteDeliveryId | The Delivery URI of the new publication. In case the alias match with the line items slug, this value will replace the line items URI.                                                                           |

--- a/src/Command/ModifyEntity/LineItem/LineItemChangeDatesCommand.php
+++ b/src/Command/ModifyEntity/LineItem/LineItemChangeDatesCommand.php
@@ -86,7 +86,8 @@ class LineItemChangeDatesCommand extends Command
 The <info>%command.name%</info> command changes the dates for specific line items.
 
 <comment>Not specifying a start-date or end-date option will nullify the value for the column.</comment>
-<comment>Dates are expected to be in the format: 2020-01-01T00:00:00+0000</comment>
+<comment>Dates are expected to be in the format: 2020-01-01T00:00:00+0000.</comment>
+<comment>You can adjust the timezone: 2020-01-01T00:00:00+0100 will be stored as 2019-12-31 23:00:00 GMT.</comment>
 
 To change both start and end date of a line item using IDs:
     <info>php %command.full_name% -i 1,2,3 --start-date <date> --end-date <date></info>
@@ -208,7 +209,7 @@ EOF
             }
 
             if ($this->isDryRun) {
-                $this->symfonyStyle->success(
+                $this->symfonyStyle->warning(
                     sprintf(
                         '[DRY RUN] %d line item(s) have been updated.',
                         $lineItemsCollection->count()
@@ -317,7 +318,7 @@ EOF
         if (!empty($dateString)) {
             try {
                 $date = Carbon::createFromFormat(Carbon::ATOM, $dateString);
-                $dateObj = $date ? $date->toDateTime() : null;
+                $dateObj = $date ? $date->setTimezone('UTC')->toDateTime() : null;
             } catch (Throwable $e) {
                 $message = sprintf(
                     '%s is an invalid date. Expected format: 2020-01-01T00:00:00+0000',

--- a/src/WebHook/UpdateLineItemDto.php
+++ b/src/WebHook/UpdateLineItemDto.php
@@ -31,7 +31,7 @@ class UpdateLineItemDto implements JsonSerializable
     public const STATUS_ERROR = 'error';
     public const STATUS_IGNORED = 'ignored';
 
-    public const NAME = 'RemoteDeliveryPublicationFinished';
+    public const NAME = 'oat\\taoPublishing\\model\\publishing\\event\\RemoteDeliveryCreatedEvent';
 
     /** @var string */
     private $id;

--- a/tests/Functional/Action/WebHook/UpdateLineItemsWebhookActionTest.php
+++ b/tests/Functional/Action/WebHook/UpdateLineItemsWebhookActionTest.php
@@ -401,7 +401,7 @@ class UpdateLineItemsWebhookActionTest extends WebTestCase
                 ],
                 [
                     'eventId' => '52a3de8dd0f270fd193f9f4bff05232f',
-                    'eventName' => 'RemoteDeliveryPublicationFinished',
+                    'eventName' => 'oat\\taoPublishing\\model\\publishing\\event\\RemoteDeliveryCreatedEvent',
                     'triggeredTimestamp' => 1565602371,
                     'eventData' => [
                         'alias' => 'wrong-alias',
@@ -410,7 +410,7 @@ class UpdateLineItemsWebhookActionTest extends WebTestCase
                 ],
                 [
                     'eventId' => 'lastDuplicatedEvent',
-                    'eventName' => 'RemoteDeliveryPublicationFinished',
+                    'eventName' => 'oat\\taoPublishing\\model\\publishing\\event\\RemoteDeliveryCreatedEvent',
                     'triggeredTimestamp' => 1565602390,
                     'eventData' => [
                         'alias' => 'lineItemSlug',
@@ -419,7 +419,7 @@ class UpdateLineItemsWebhookActionTest extends WebTestCase
                 ],
                 [
                     'eventId' => 'duplicated',
-                    'eventName' => 'RemoteDeliveryPublicationFinished',
+                    'eventName' => 'oat\\taoPublishing\\model\\publishing\\event\\RemoteDeliveryCreatedEvent',
                     'triggeredTimestamp' => 1565602380,
                     'eventData' => [
                         'alias' => 'lineItemSlug',

--- a/tests/Functional/Command/ModifyEntity/LineItem/LineItemChangeDatesCommandTest.php
+++ b/tests/Functional/Command/ModifyEntity/LineItem/LineItemChangeDatesCommandTest.php
@@ -146,7 +146,7 @@ class LineItemChangeDatesCommandTest extends KernelTestCase
 
         self::assertStringContainsString('[NOTE] Checking line items to be updated...', $display);
         self::assertStringContainsString(
-            sprintf('[OK] [DRY RUN] %d line item(s) have been updated.', count($lineItemIds)),
+            sprintf('[WARNING] [DRY RUN] %d line item(s) have been updated.', count($lineItemIds)),
             $display
         );
 
@@ -451,6 +451,18 @@ class LineItemChangeDatesCommandTest extends KernelTestCase
                     'lineItemIds' => [4, 5, 6],
                     'start_at' => null,
                     'end_at' => '2020-01-01 00:00:00',
+                ],
+            ],
+            'usingDatesWithTimeZone' => [
+                'parameters' => [
+                    '-s' => 'slug-1',
+                    '--start-date' => '2020-01-01T00:00:00+0100',
+                    '--end-date' => '2020-01-10T00:00:00+0100',
+                ],
+                'persistedData' => [
+                    'lineItemIds' => [4],
+                    'start_at' => '2019-12-31 23:00:00',
+                    'end_at' => '2020-01-09 23:00:00',
                 ],
             ],
         ];

--- a/tests/Unit/Request/ParamConverter/UpdateLineItemWebHookParamConverterTest.php
+++ b/tests/Unit/Request/ParamConverter/UpdateLineItemWebHookParamConverterTest.php
@@ -68,12 +68,14 @@ class UpdateLineItemWebHookParamConverterTest extends TestCase
             Request::class
         );
 
+        $eventName = 'oat\\\\taoPublishing\\\\model\\\\publishing\\\\event\\\\RemoteDeliveryCreatedEvent';
+
         $payload = '{
                     "source":"https://someinstance.taocloud.org/",
                     "events":[
                         {
                             "eventId":"52a3de8dd0f270fd193f9f4bff05232c",
-                            "eventName":"RemoteDeliveryPublicationFinished",
+                            "eventName":"' . $eventName . '",
                             "triggeredTimestamp":1565602390,
                             "eventData":{
                                 "alias":"qti-interactions-delivery",
@@ -116,7 +118,10 @@ class UpdateLineItemWebHookParamConverterTest extends TestCase
         self::assertInstanceOf(UpdateLineItemDto::class, $updateLineItemDto);
 
         self::assertSame("52a3de8dd0f270fd193f9f4bff05232c", $updateLineItemDto->getId());
-        self::assertSame("RemoteDeliveryPublicationFinished", $updateLineItemDto->getName());
+        self::assertSame(
+            'oat\\taoPublishing\\model\\publishing\\event\\RemoteDeliveryCreatedEvent',
+            $updateLineItemDto->getName()
+        );
         self::assertSame(1565602390, $updateLineItemDto->getTriggeredTime()->getTimestamp());
         self::assertSame("qti-interactions-delivery", $updateLineItemDto->getSlug());
         self::assertSame(

--- a/tests/Unit/Webhook/Service/UpdateLineItemsServiceTest.php
+++ b/tests/Unit/Webhook/Service/UpdateLineItemsServiceTest.php
@@ -121,7 +121,7 @@ class UpdateLineItemsServiceTest extends TestCase
         $updateLineItemCollection = new UpdateLineItemCollection(
             new UpdateLineItemDto(
                 '52a3de8dd0f270fd193f9f4bff05232f',
-                'RemoteDeliveryPublicationFinished',
+                'oat\\taoPublishing\\model\\publishing\\event\\RemoteDeliveryCreatedEvent',
                 'https://tao.instance/ontologies/tao.rdf#i5fb5',
                 (new DateTimeImmutable())->setTimestamp(1565602371),
                 'qti-interactions-delivery'
@@ -175,14 +175,14 @@ class UpdateLineItemsServiceTest extends TestCase
         $updateLineItemCollection = new UpdateLineItemCollection(
             new UpdateLineItemDto(
                 '111',
-                'RemoteDeliveryPublicationFinished',
+                'oat\\taoPublishing\\model\\publishing\\event\\RemoteDeliveryCreatedEvent',
                 'https://tao.instance/ontologies/tao.rdf#i5fb5',
                 (new DateTimeImmutable())->setTimestamp(1565602380),
                 'qti-interactions-delivery'
             ),
             new UpdateLineItemDto(
                 '222',
-                'RemoteDeliveryPublicationFinished',
+                'oat\\taoPublishing\\model\\publishing\\event\\RemoteDeliveryCreatedEvent',
                 'https://tao.instance/ontologies/tao.rdf#duplicated',
                 (new DateTimeImmutable())->setTimestamp(1565602371),
                 'qti-interactions-delivery'
@@ -228,7 +228,7 @@ class UpdateLineItemsServiceTest extends TestCase
         $updateLineItemCollection = new UpdateLineItemCollection(
             new UpdateLineItemDto(
                 '52a3de8dd0f270fd193f9f4bff05232f',
-                'RemoteDeliveryPublicationFinished',
+                'oat\\taoPublishing\\model\\publishing\\event\\RemoteDeliveryCreatedEvent',
                 'https://tao.instance/ontologies/tao.rdf#i5fb5',
                 (new DateTimeImmutable())->setTimestamp(1565602371),
                 'qti-interactions-delivery'


### PR DESCRIPTION
### Fixed
- Renamed webhook event name from `RemoteDeliveryPublicationFinished` to `oat\\taoPublishing\\model\\publishing\\event\\RemoteDeliveryCreatedEvent`.
- Fixed [roster:modify-entity:line-item:change-dates](docs/cli/modify-entity-line-item-change-dates-command.md) command to allow proper use of timezone offset. 
  We now convert the input date(s) to UTC before persisting it.
