### PR TITLE
[RO-71] Avoid calling deprecated doctrine ping method

### DIFF
--- a/src/Service/HealthCheck/HealthCheckService.php
+++ b/src/Service/HealthCheck/HealthCheckService.php
@@ -61,13 +61,13 @@ class HealthCheckService
         try {
             $testQuery = $connection->getDatabasePlatform()->getDummySelectSQL();
             $testQueryResult = (bool)$connection->fetchOne($testQuery);
-        } catch (Exception $e) {
+        } catch (Exception $exception) {
             $testQueryResult = $connection->isConnected();
 
             $this->logger->critical(
                 sprintf(
                     'DB connection unavailable. Got `%s` exception from DBAL',
-                    $e->getMessage()
+                    $exception->getMessage()
                 )
             );
         }


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/RO-71

### Fixed
- Changed implementation of `HealthCheckService` to avoid calling deprecated `ping` method