### PR TITLE
Simple Roster 3.X - Add xdebug version to Dockerfile to install the SR application without failing

### DIFF
--- a/docker/phpfpm/Dockerfile
+++ b/docker/phpfpm/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add sqlite-dev libsodium-dev \
     	zlib-dev icu-dev g++ libzip-dev postgresql-dev zstd-dev bash
 
 RUN docker-php-ext-configure mysqli --with-mysqli=mysqlnd \
-    && yes | pecl install igbinary apcu xdebug redis \
+    && yes | pecl install igbinary apcu xdebug-3.1.6 redis \
     && docker-php-ext-install pdo \
     && docker-php-ext-install intl \
     && docker-php-ext-install mysqli \


### PR DESCRIPTION
Related to ticket https://oat-sa.atlassian.net/browse/LSI-1993
Add xdebug version to Dockerfile to install the SR application without failing

![image](https://user-images.githubusercontent.com/57711251/230888962-98ee3c23-c06f-4eb2-ab78-bbf47d597167.png)
