### PR TITLE
Added missing msgpack to dockerfile, fix traefik labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unrelease
+### Fixed
+- Updated Docker configuration by adding the missing `msgpack` dependency and fixing Traefik labels
+
 ## 3.0.0 - 2022-10-30
 ### Changed
 - Raised minimum required PHP version from `7.4` to `8.1`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
             - "traefik.frontend.rule=Host:simple-roster.docker.localhost"
             - "traefik.docker.network=oat-docker"
             - "traefik.port=80"
+            - "traefik.http.routers.simple-roster-nginx.rule=Host(`simple-roster.docker.localhost`)"
 
     simple-roster-phpfpm:
         container_name: simple-roster-phpfpm

--- a/docker/phpfpm/Dockerfile
+++ b/docker/phpfpm/Dockerfile
@@ -4,10 +4,10 @@ ENV SYMFONY_DEPRECATIONS_HELPER=disabled
 ENV XDEBUG_MODE=off
 
 RUN apt-get update && apt-get install -y libsqlite3-dev libsodium-dev \
-    	zlib1g-dev libicu-dev g++ libzip-dev libpq-dev libzip-dev libzstd-dev bash
+    	zlib1g-dev libicu-dev g++ libzip-dev libpq-dev libzip-dev libzstd-dev liblz4-dev bash
 
 RUN docker-php-ext-configure mysqli --with-mysqli=mysqlnd \
-    && yes | pecl install igbinary apcu xdebug-3.1.6 redis \
+    && yes | pecl install igbinary apcu xdebug-3.1.6 msgpack redis \
     && docker-php-ext-install pdo \
     && docker-php-ext-install intl \
     && docker-php-ext-install mysqli \
@@ -22,6 +22,7 @@ RUN docker-php-ext-configure mysqli --with-mysqli=mysqlnd \
     && docker-php-ext-install sodium \
     && docker-php-ext-enable apcu \
     && docker-php-ext-enable igbinary \
+    && docker-php-ext-enable msgpack \
     && docker-php-ext-enable redis \
     && docker-php-ext-enable xdebug
 


### PR DESCRIPTION
This PR adds missing Traefik v2 labels to the simple-roster-nginx service, allowing the application to be correctly routed under:
`https://simple-roster.docker.localhost`

Previously, the service used deprecated Traefik v1 labels (traefik.backend, traefik.frontend.rule), which Traefik v2 ignores, resulting in the route not being registered.

---

PHP-FPM Dockerfile fixes:

Added installation of required PECL extensions: `msgpack`
Installed missing system dependency: `liblz4-dev`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added explicit HTTP routing for the web service to improve local accessibility.
  * Expanded PHP-FPM environment with additional system dependency and several PHP extensions for better DB connectivity, compression, and runtime features.
* **Documentation**
  * Updated changelog with Docker configuration and runtime environment fixes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->