### PR TITLE
Feat/lsi 7353/simple roster upgrade support

### DIFF
--- a/docker-compose-service.yml
+++ b/docker-compose-service.yml
@@ -12,7 +12,6 @@ services:
         working_dir: /etc/nginx/conf.d
         labels:
             - "traefik.backend=simple-roster-nginx"
-            - "traefik.frontend.rule=Host:simple-roster.docker.localhost"
             - "traefik.http.routers.simple-roster-nginx.rule=Host(`${SR_HOST:-simple-roster.docker.localhost}`)"
             - "traefik.docker.network=oat-docker"
             - "traefik.port=80"

--- a/docker-compose-service.yml
+++ b/docker-compose-service.yml
@@ -1,6 +1,6 @@
 services:
     simple-roster-nginx:
-        container_name: ${SIMPLE_ROSTER_NGINX_CONTAINER_NAME:-simple-roster-nginx}
+        container_name: simple-roster-nginx${CONTAINER_SUFFIX}
         image: nginx:stable
         networks:
             - simple-roster

--- a/docker-compose-service.yml
+++ b/docker-compose-service.yml
@@ -1,0 +1,18 @@
+services:
+    simple-roster-nginx:
+        container_name: ${SIMPLE_ROSTER_NGINX_CONTAINER_NAME:-simple-roster-nginx}
+        image: nginx:stable
+        networks:
+            - simple-roster
+            - depp-delivery
+            - oat-docker
+        volumes:
+            - .:/var/www/html:cached
+            - ./docker/nginx/nginx.conf:/etc/nginx/conf.d/default.conf:cached
+        working_dir: /etc/nginx/conf.d
+        labels:
+            - "traefik.backend=simple-roster-nginx"
+            - "traefik.frontend.rule=Host:simple-roster.docker.localhost"
+            - "traefik.http.routers.simple-roster-nginx.rule=Host(`${SR_HOST:-simple-roster.docker.localhost}`)"
+            - "traefik.docker.network=oat-docker"
+            - "traefik.port=80"

--- a/docker-compose-service.yml
+++ b/docker-compose-service.yml
@@ -2,6 +2,8 @@ services:
     simple-roster-nginx:
         container_name: simple-roster-nginx${CONTAINER_SUFFIX}
         image: nginx:stable
+        depends_on:
+            - simple-roster-phpfpm
         networks:
             - simple-roster
             - depp-delivery

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ include:
 
 services:
     simple-roster-phpfpm:
-        container_name: simple-roster-phpfpm
+        container_name: simple-roster-phpfpm${CONTAINER_SUFFIX}
         env_file:
             - .env.docker
         build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,23 +1,9 @@
 version: '3'
 
-services:
-    simple-roster-nginx:
-        container_name: simple-roster-nginx
-        image: nginx:stable
-        networks:
-            - simple-roster
-            - oat-docker
-        volumes:
-            - .:/var/www/html:cached
-            - ./docker/nginx/nginx.conf:/etc/nginx/conf.d/default.conf:cached
-        working_dir: /etc/nginx/conf.d
-        labels:
-            - "traefik.backend=simple-roster-nginx"
-            - "traefik.frontend.rule=Host:simple-roster.docker.localhost"
-            - "traefik.docker.network=oat-docker"
-            - "traefik.port=80"
-            - "traefik.http.routers.simple-roster-nginx.rule=Host(`simple-roster.docker.localhost`)"
+include:
+    - docker-compose-service.yml
 
+services:
     simple-roster-phpfpm:
         container_name: simple-roster-phpfpm
         env_file:
@@ -102,6 +88,8 @@ volumes:
 
 networks:
     simple-roster:
+        driver: bridge
+    depp-delivery:
         driver: bridge
     oat-docker:
         external: true


### PR DESCRIPTION
**Extract Nginx container to a separate file**

This PR refactors the current setup by extracting the Nginx container configuration into a separate file.
Prepared the structure for easier reuse in the delivery Docker stack.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reorganized Compose layout to separate auxiliary service configuration for simpler inclusion.
  * Added a lightweight web proxy service to serve static content and integrate with routing.
  * Introduced a new bridge network to improve inter-service connectivity.
  * Adjusted backend service naming to better support multi-instance/local development workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->