### PR TITLE
Feat/lsi 7315/download endpoint

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -26,7 +26,7 @@ security:
             security: false
 
         api_key:
-            pattern: '^%app.route_prefix%/v1/(bulk|line-items|upload|status)(?:$|/)'
+            pattern: '^%app.route_prefix%/v1/(bulk|line-items|upload|status|download)(?:$|/)'
             provider: app_user_provider
             custom_authenticators:
                 - OAT\SimpleRoster\Security\Authenticator\ApiKeyAuthenticator

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -74,6 +74,11 @@ getRosteringImportStatus:
   methods: GET
   defaults: { _controller: OAT\SimpleRoster\Action\RosteringImport\GetRosteringImportStatusAction }
 
+getRosteringImportDownload:
+  path: '%app.route_prefix%/v1/download/{referenceId}'
+  methods: GET
+  defaults: { _controller: OAT\SimpleRoster\Action\RosteringImport\GetRosteringImportDownloadAction }
+
 listLtiInstances:
   path: '%app.route_prefix%/v1/lti-instances'
   methods: GET

--- a/openapi/api_v1.yml
+++ b/openapi/api_v1.yml
@@ -598,6 +598,35 @@ paths:
                     $ref: '#/components/responses/NotFoundResponse'
                 500:
                     $ref: '#/components/responses/InternalServerErrorResponse'
+
+    /v1/download/{referenceId}:
+        get:
+            security:
+                -   bearerAuth: []
+            summary: Get signed URL for processed rostering import result
+            tags:
+                - FileUpload
+            operationId: getResultFileDownloadUrl
+            parameters:
+                -   in: path
+                    name: referenceId
+                    required: true
+                    schema:
+                        type: string
+                    description: Reference ID returned by the upload endpoint.
+            responses:
+                200:
+                    $ref: '#/components/responses/ResultFileDownloadResponse'
+                400:
+                    $ref: '#/components/responses/BadRequestResponse'
+                401:
+                    $ref: '#/components/responses/UnauthorizedResponse'
+                403:
+                    $ref: '#/components/responses/AccessDeniedResponse'
+                404:
+                    $ref: '#/components/responses/NotFoundResponse'
+                500:
+                    $ref: '#/components/responses/InternalServerErrorResponse'
 components:
     securitySchemes:
         apiKeyAuth:
@@ -1127,9 +1156,6 @@ components:
                             result:
                                 type: object
                                 properties:
-                                    referenceId:
-                                        type: string
-                                        description: Reference ID of the uploaded file.
                                     status:
                                         type: string
                                         description: Processing status.
@@ -1146,7 +1172,13 @@ components:
                                         items:
                                             type: string
                                         description: Import messages, usually errors.
-                                    resultFileUrl:
-                                        type: string
-                                        nullable: true
-                                        description: Signed URL to the result file (prod only).
+        ResultFileDownloadResponse:
+            description: Download URL response
+            content:
+                application/json:
+                    schema:
+                        type: object
+                        properties:
+                            signedUrl:
+                                type: string
+                                description: Temporary signed URL to download rostering result file.

--- a/src/Action/RosteringImport/GetRosteringImportDownloadAction.php
+++ b/src/Action/RosteringImport/GetRosteringImportDownloadAction.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OAT\SimpleRoster\Action\RosteringImport;
+
+use OAT\SimpleRoster\Request\Validator\RosteringImport\RosteringImportReferenceIdValidator;
+use OAT\SimpleRoster\Responder\SerializerResponder;
+use OAT\SimpleRoster\Service\Rostering\Exception\RosteringStatusException;
+use OAT\SimpleRoster\Service\Rostering\RosteringImportStatusService;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class GetRosteringImportDownloadAction
+{
+    public function __construct(
+        private readonly RosteringImportStatusService $statusService,
+        private readonly RosteringImportReferenceIdValidator $referenceIdValidator,
+        private readonly SerializerResponder $responder
+    ) {
+    }
+
+    public function __invoke(string $referenceId): JsonResponse
+    {
+        $validatedReferenceId = $this->referenceIdValidator->validate($referenceId);
+
+        try {
+            $signedUrl = $this->statusService->getDownloadUrl($validatedReferenceId);
+        } catch (RosteringStatusException $exception) {
+            throw new BadRequestHttpException('Unable to resolve rostering import download URL.', $exception);
+        }
+
+        if ($signedUrl === null) {
+            throw new NotFoundHttpException(
+                sprintf('Download URL for referenceId "%s" is not available.', $validatedReferenceId)
+            );
+        }
+
+        return $this->responder->createJsonResponse(['signedUrl' => $signedUrl], Response::HTTP_OK);
+    }
+}

--- a/src/Service/Rostering/Dto/RosteringImportStatus.php
+++ b/src/Service/Rostering/Dto/RosteringImportStatus.php
@@ -15,26 +15,20 @@ class RosteringImportStatus
         private readonly string $referenceId,
         private readonly string $status,
         private readonly int $fileLine,
-        private readonly array $messages,
-        private readonly ?string $resultFileUrl
+        private readonly array $messages
     ) {
     }
 
     public static function pending(string $referenceId): self
     {
-        return new self($referenceId, 'pending', 0, [], null);
+        return new self($referenceId, 'pending', 0, []);
     }
 
     /**
      * @param array<string, mixed> $result
      */
-    public static function fromApiResult(array $result): self
+    public static function fromApiResult(array $result, string $referenceId): self
     {
-        if (!isset($result['referenceId']) || !is_string($result['referenceId']) || trim($result['referenceId']) === '') {
-            throw new InvalidArgumentException('Invalid "referenceId" in Principal Portal status payload.');
-        }
-        $referenceId = trim($result['referenceId']);
-
         if (!isset($result['status']) || !is_string($result['status']) || trim($result['status']) === '') {
             throw new InvalidArgumentException('Invalid "status" in Principal Portal status payload.');
         }
@@ -57,24 +51,10 @@ class RosteringImportStatus
             $messages[] = trim($message);
         }
 
-        if (!array_key_exists('resultFileUrl', $result)) {
-            throw new InvalidArgumentException('Invalid "resultFileUrl" in Principal Portal status payload.');
-        }
-
-        $resultFileUrl = null;
-        if ($result['resultFileUrl'] !== null) {
-            if (!is_string($result['resultFileUrl'])) {
-                throw new InvalidArgumentException('Invalid "resultFileUrl" in Principal Portal status payload.');
-            }
-
-            $trimmedUrl = trim($result['resultFileUrl']);
-            $resultFileUrl = $trimmedUrl === '' ? null : $trimmedUrl;
-        }
-
-        return new self($referenceId, $status, $fileLine, $messages, $resultFileUrl);
+        return new self($referenceId, $status, $fileLine, $messages);
     }
 
-    public static function fromImport(RosteringImport $import, ?string $resultFileUrl): self
+    public static function fromImport(RosteringImport $import): self
     {
         $messages = [];
         $errorMessage = $import->getErrorMessage();
@@ -86,8 +66,7 @@ class RosteringImportStatus
             $import->getReferenceId(),
             $import->getStatus(),
             $import->getTotalRows() ?? 0,
-            $messages,
-            $resultFileUrl
+            $messages
         );
     }
 
@@ -114,38 +93,20 @@ class RosteringImportStatus
         return $this->messages;
     }
 
-    public function getResultFileUrl(): ?string
-    {
-        return $this->resultFileUrl;
-    }
-
     public function isProcessed(): bool
     {
         return $this->status === self::STATUS_PROCESSED;
     }
 
-    public function withResultFileUrl(?string $resultFileUrl): self
-    {
-        return new self(
-            $this->referenceId,
-            $this->status,
-            $this->fileLine,
-            $this->messages,
-            $resultFileUrl
-        );
-    }
-
     /**
-     * @return array{referenceId: string, status: string, fileLine: int, messages: array<int, string>, resultFileUrl: ?string}
+     * @return array{status: string, fileLine: int, messages: array<int, string>}
      */
     public function toArray(): array
     {
         return [
-            'referenceId' => $this->referenceId,
             'status' => $this->status,
             'fileLine' => $this->fileLine,
             'messages' => $this->messages,
-            'resultFileUrl' => $this->resultFileUrl,
         ];
     }
 }

--- a/src/Service/Rostering/PrincipalPortalStatusHttpClient.php
+++ b/src/Service/Rostering/PrincipalPortalStatusHttpClient.php
@@ -50,7 +50,7 @@ class PrincipalPortalStatusHttpClient implements PrincipalPortalStatusClientInte
                 throw new RosteringStatusException('Invalid Principal Portal status payload.');
             }
 
-            return RosteringImportStatus::fromApiResult($decodedBody['result']);
+            return RosteringImportStatus::fromApiResult($decodedBody['result'], $referenceId);
         } catch (Throwable $exception) {
             if ($exception instanceof RosteringStatusException) {
                 throw $exception;

--- a/src/Service/Rostering/RosteringImportStatusMerger.php
+++ b/src/Service/Rostering/RosteringImportStatusMerger.php
@@ -21,8 +21,7 @@ class RosteringImportStatusMerger
             $srStatus->getReferenceId(),
             $this->mergeStatus($srStatus->getStatus(), $ppStatus->getStatus()),
             max($srStatus->getFileLine(), $ppStatus->getFileLine()),
-            $this->mergeMessages($srStatus->getMessages(), $ppStatus->getMessages()),
-            null
+            $this->mergeMessages($srStatus->getMessages(), $ppStatus->getMessages())
         );
     }
 

--- a/src/Service/Rostering/RosteringImportStatusService.php
+++ b/src/Service/Rostering/RosteringImportStatusService.php
@@ -63,6 +63,11 @@ class RosteringImportStatusService
             return $this->resultFileUrlProvider->generate($this->fileKeyResolver->outputFileKey($referenceId));
         }
 
+        $ppOutputFileKey = $this->fileKeyResolver->principalPortalOutputFileKey($referenceId);
+        if (!$this->fileStorage->exists($ppOutputFileKey)) {
+            return null;
+        }
+
         $mergedOutputFileKey = $this->resultFileMerger->getOrCreateMergedOutputFileKey($referenceId);
 
         return $this->resultFileUrlProvider->generate($mergedOutputFileKey);

--- a/src/Service/Rostering/RosteringImportStatusService.php
+++ b/src/Service/Rostering/RosteringImportStatusService.php
@@ -28,24 +28,17 @@ class RosteringImportStatusService
     public function getStatus(string $referenceId): ?RosteringImportStatus
     {
         if (!$this->principalPortalEnabled) {
-            return $this->resolveLocalStatus($referenceId, true);
+            return $this->resolveLocalStatus($referenceId);
         }
 
-        $localStatus = $this->resolveLocalStatus($referenceId, false);
+        $localStatus = $this->resolveLocalStatus($referenceId);
         if ($localStatus === null) {
             return null;
         }
 
         try {
             $principalPortalStatus = $this->principalPortalStatusClient->fetchStatus($referenceId);
-            $mergedStatus = $this->statusMerger->merge($localStatus, $principalPortalStatus);
-            if (!$mergedStatus->isProcessed()) {
-                return $mergedStatus;
-            }
-
-            $mergedOutputFileKey = $this->resultFileMerger->getOrCreateMergedOutputFileKey($referenceId);
-
-            return $mergedStatus->withResultFileUrl($this->resultFileUrlProvider->generate($mergedOutputFileKey));
+            return $this->statusMerger->merge($localStatus, $principalPortalStatus);
         } catch (RosteringStatusException $exception) {
             $this->logger->error(
                 sprintf('Unable to resolve merged rostering status for referenceId "%s".', $referenceId),
@@ -59,7 +52,23 @@ class RosteringImportStatusService
         }
     }
 
-    private function resolveLocalStatus(string $referenceId, bool $withResultFileUrl): ?RosteringImportStatus
+    public function getDownloadUrl(string $referenceId): ?string
+    {
+        $status = $this->getStatus($referenceId);
+        if ($status === null || !$status->isProcessed()) {
+            return null;
+        }
+
+        if (!$this->principalPortalEnabled) {
+            return $this->resultFileUrlProvider->generate($this->fileKeyResolver->outputFileKey($referenceId));
+        }
+
+        $mergedOutputFileKey = $this->resultFileMerger->getOrCreateMergedOutputFileKey($referenceId);
+
+        return $this->resultFileUrlProvider->generate($mergedOutputFileKey);
+    }
+
+    private function resolveLocalStatus(string $referenceId): ?RosteringImportStatus
     {
         $import = $this->rosteringImportRepository->findOneBy(['referenceId' => $referenceId]);
         if (!$import instanceof RosteringImport) {
@@ -70,10 +79,6 @@ class RosteringImportStatusService
             return null;
         }
 
-        $resultFileUrl = $withResultFileUrl && $import->isProcessed()
-            ? $this->resultFileUrlProvider->generate($this->fileKeyResolver->outputFileKey($referenceId))
-            : null;
-
-        return RosteringImportStatus::fromImport($import, $resultFileUrl);
+        return RosteringImportStatus::fromImport($import);
     }
 }

--- a/src/Service/Rostering/S3ResultFileUrlProvider.php
+++ b/src/Service/Rostering/S3ResultFileUrlProvider.php
@@ -45,7 +45,7 @@ class S3ResultFileUrlProvider implements ResultFileUrlProviderInterface
 
             return (string) $request->getUri();
         } catch (Throwable $exception) {
-            $this->logger->warning(
+            $this->logger->error(
                 sprintf('Unable to generate signed result file URL for file key "%s".', $fileKey),
                 [
                     'fileKey' => $fileKey,

--- a/tests/Functional/Action/RosteringImport/GetRosteringImportDownloadActionTest.php
+++ b/tests/Functional/Action/RosteringImport/GetRosteringImportDownloadActionTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OAT\SimpleRoster\Tests\Functional\Action\RosteringImport;
+
+use OAT\SimpleRoster\Service\Rostering\Exception\RosteringStatusException;
+use OAT\SimpleRoster\Service\Rostering\RosteringImportStatusService;
+use OAT\SimpleRoster\Tests\AppWebTestCase;
+use OAT\SimpleRoster\Tests\Traits\DatabaseTestingTrait;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class GetRosteringImportDownloadActionTest extends AppWebTestCase
+{
+    use DatabaseTestingTrait;
+
+    private const DOWNLOAD_ENDPOINT_PREFIX = '/api/v1/download/';
+    private const AUTH_TEST_REFERENCE_ID = '76091d1a-3ef5-438d-a88f-8df73bb5f919';
+    private const NOT_FOUND_REFERENCE_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+    private const INVALID_REFERENCE_ID = 'ref..invalid';
+
+    private KernelBrowser $kernelBrowser;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->kernelBrowser = self::createClient([], ['HTTP_AUTHORIZATION' => 'Bearer testApiKey']);
+        $this->setUpDatabase();
+    }
+
+    public function testItRequiresApiKeyAuthentication(): void
+    {
+        $this->kernelBrowser->request(
+            Request::METHOD_GET,
+            self::DOWNLOAD_ENDPOINT_PREFIX . self::AUTH_TEST_REFERENCE_ID,
+            [],
+            [],
+            ['HTTP_AUTHORIZATION' => 'Bearer invalid']
+        );
+
+        self::assertSame(Response::HTTP_UNAUTHORIZED, $this->kernelBrowser->getResponse()->getStatusCode());
+    }
+
+    public function testItReturnsNotFoundWhenDownloadIsNotAvailable(): void
+    {
+        $this->kernelBrowser->request(Request::METHOD_GET, self::DOWNLOAD_ENDPOINT_PREFIX . self::NOT_FOUND_REFERENCE_ID);
+
+        self::assertSame(Response::HTTP_NOT_FOUND, $this->kernelBrowser->getResponse()->getStatusCode());
+    }
+
+    public function testItReturnsBadRequestForInvalidReferenceId(): void
+    {
+        $this->kernelBrowser->request(Request::METHOD_GET, self::DOWNLOAD_ENDPOINT_PREFIX . self::INVALID_REFERENCE_ID);
+
+        self::assertSame(Response::HTTP_BAD_REQUEST, $this->kernelBrowser->getResponse()->getStatusCode());
+    }
+
+    public function testItReturnsBadRequestWhenDownloadResolutionFails(): void
+    {
+        $statusService = $this->createMock(RosteringImportStatusService::class);
+        $statusService
+            ->expects(self::once())
+            ->method('getDownloadUrl')
+            ->with(self::AUTH_TEST_REFERENCE_ID)
+            ->willThrowException(new RosteringStatusException('Unable to merge worker output files.'));
+        self::getContainer()->set(RosteringImportStatusService::class, $statusService);
+
+        $this->kernelBrowser->request(
+            Request::METHOD_GET,
+            self::DOWNLOAD_ENDPOINT_PREFIX . self::AUTH_TEST_REFERENCE_ID
+        );
+
+        self::assertSame(Response::HTTP_BAD_REQUEST, $this->kernelBrowser->getResponse()->getStatusCode());
+        $decodedResponse = json_decode(
+            (string) $this->kernelBrowser->getResponse()->getContent(),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+        self::assertSame('Unable to resolve rostering import download URL.', $decodedResponse['error']['message']);
+    }
+
+    public function testItReturnsSignedUrlWhenDownloadIsAvailable(): void
+    {
+        $statusService = $this->createMock(RosteringImportStatusService::class);
+        $statusService
+            ->expects(self::once())
+            ->method('getDownloadUrl')
+            ->with(self::AUTH_TEST_REFERENCE_ID)
+            ->willReturn('https://signed-url');
+        self::getContainer()->set(RosteringImportStatusService::class, $statusService);
+
+        $this->kernelBrowser->request(
+            Request::METHOD_GET,
+            self::DOWNLOAD_ENDPOINT_PREFIX . self::AUTH_TEST_REFERENCE_ID
+        );
+
+        self::assertSame(Response::HTTP_OK, $this->kernelBrowser->getResponse()->getStatusCode());
+        $decodedResponse = json_decode(
+            (string) $this->kernelBrowser->getResponse()->getContent(),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+        self::assertSame('https://signed-url', $decodedResponse['signedUrl']);
+    }
+}

--- a/tests/Functional/Action/RosteringImport/GetRosteringImportStatusActionTest.php
+++ b/tests/Functional/Action/RosteringImport/GetRosteringImportStatusActionTest.php
@@ -104,11 +104,11 @@ class GetRosteringImportStatusActionTest extends AppWebTestCase
             JSON_THROW_ON_ERROR
         );
 
-        self::assertSame($referenceId, $decodedResponse['result']['referenceId']);
         self::assertSame('pending', $decodedResponse['result']['status']);
         self::assertSame(0, $decodedResponse['result']['fileLine']);
         self::assertSame([], $decodedResponse['result']['messages']);
-        self::assertNull($decodedResponse['result']['resultFileUrl']);
+        self::assertArrayNotHasKey('referenceId', $decodedResponse['result']);
+        self::assertArrayNotHasKey('resultFileUrl', $decodedResponse['result']);
     }
 
     public function testItReturnsProcessingStatusFromImportRow(): void
@@ -127,11 +127,11 @@ class GetRosteringImportStatusActionTest extends AppWebTestCase
             JSON_THROW_ON_ERROR
         );
 
-        self::assertSame($referenceId, $decodedResponse['result']['referenceId']);
         self::assertSame('processing', $decodedResponse['result']['status']);
         self::assertSame(0, $decodedResponse['result']['fileLine']);
         self::assertSame([], $decodedResponse['result']['messages']);
-        self::assertNull($decodedResponse['result']['resultFileUrl']);
+        self::assertArrayNotHasKey('referenceId', $decodedResponse['result']);
+        self::assertArrayNotHasKey('resultFileUrl', $decodedResponse['result']);
     }
 
     public function testItReturnsFailedStatusWithErrorMessage(): void
@@ -152,7 +152,8 @@ class GetRosteringImportStatusActionTest extends AppWebTestCase
         self::assertSame('failed', $decodedResponse['result']['status']);
         self::assertSame(100, $decodedResponse['result']['fileLine']);
         self::assertSame(['Global import error'], $decodedResponse['result']['messages']);
-        self::assertNull($decodedResponse['result']['resultFileUrl']);
+        self::assertArrayNotHasKey('referenceId', $decodedResponse['result']);
+        self::assertArrayNotHasKey('resultFileUrl', $decodedResponse['result']);
     }
 
     private function storeInputFile(string $referenceId): void

--- a/tests/Unit/Service/Rostering/PrincipalPortalStatusHttpClientTest.php
+++ b/tests/Unit/Service/Rostering/PrincipalPortalStatusHttpClientTest.php
@@ -37,7 +37,7 @@ class PrincipalPortalStatusHttpClientTest extends TestCase
             self::assertSame(sprintf('Bearer %s', $appApiKey), $authorizationHeader);
 
             return new MockResponse(
-                '{"result":{"referenceId":"ref-1","status":"processed","fileLine":12,"messages":[],"resultFileUrl":"http://file"}}',
+                '{"result":{"status":"processed","fileLine":12,"messages":[]}}',
                 ['http_code' => 200]
             );
         });

--- a/tests/Unit/Service/Rostering/RosteringImportStatusMergerTest.php
+++ b/tests/Unit/Service/Rostering/RosteringImportStatusMergerTest.php
@@ -15,8 +15,8 @@ class RosteringImportStatusMergerTest extends TestCase
         $subject = new RosteringImportStatusMerger();
 
         $merged = $subject->merge(
-            new RosteringImportStatus('ref-1', 'processed', 8, [], null),
-            new RosteringImportStatus('ref-1', 'processed', 10, [], null)
+            new RosteringImportStatus('ref-1', 'processed', 8, []),
+            new RosteringImportStatus('ref-1', 'processed', 10, [])
         );
 
         self::assertSame('processed', $merged->getStatus());
@@ -28,8 +28,8 @@ class RosteringImportStatusMergerTest extends TestCase
         $subject = new RosteringImportStatusMerger();
 
         $merged = $subject->merge(
-            new RosteringImportStatus('ref-1', 'processing', 4, [], null),
-            new RosteringImportStatus('ref-1', 'processing', 9, [], null)
+            new RosteringImportStatus('ref-1', 'processing', 4, []),
+            new RosteringImportStatus('ref-1', 'processing', 9, [])
         );
 
         self::assertSame('processing', $merged->getStatus());
@@ -41,8 +41,8 @@ class RosteringImportStatusMergerTest extends TestCase
         $subject = new RosteringImportStatusMerger();
 
         $merged = $subject->merge(
-            new RosteringImportStatus('ref-1', 'processing', 7, ['SR processing'], null),
-            new RosteringImportStatus('ref-1', 'pending', 10, ['PP pending'], null)
+            new RosteringImportStatus('ref-1', 'processing', 7, ['SR processing']),
+            new RosteringImportStatus('ref-1', 'pending', 10, ['PP pending'])
         );
 
         self::assertSame('pending', $merged->getStatus());
@@ -55,8 +55,8 @@ class RosteringImportStatusMergerTest extends TestCase
         $subject = new RosteringImportStatusMerger();
 
         $merged = $subject->merge(
-            new RosteringImportStatus('ref-1', 'processed', 5, [], null),
-            new RosteringImportStatus('ref-1', 'failed', 5, ['Import failed in PP'], null)
+            new RosteringImportStatus('ref-1', 'processed', 5, []),
+            new RosteringImportStatus('ref-1', 'failed', 5, ['Import failed in PP'])
         );
 
         self::assertSame('failed', $merged->getStatus());

--- a/tests/Unit/Service/Rostering/RosteringImportStatusServiceTest.php
+++ b/tests/Unit/Service/Rostering/RosteringImportStatusServiceTest.php
@@ -37,10 +37,8 @@ class RosteringImportStatusServiceTest extends TestCase
             ->willReturn($import);
 
         $resultFileUrlProvider
-            ->expects(self::once())
-            ->method('generate')
-            ->with($resolver->outputFileKey('ref-1'))
-            ->willReturn('http://local-output');
+            ->expects(self::never())
+            ->method('generate');
 
         $principalPortalStatusClient
             ->expects(self::never())
@@ -61,10 +59,9 @@ class RosteringImportStatusServiceTest extends TestCase
 
         self::assertInstanceOf(RosteringImportStatus::class, $status);
         self::assertSame('processed', $status->getStatus());
-        self::assertSame('http://local-output', $status->getResultFileUrl());
     }
 
-    public function testItReturnsMergedStatusAndMergedOutputFileUrlWhenIntegrationIsEnabled(): void
+    public function testItReturnsMergedStatusWhenIntegrationIsEnabled(): void
     {
         $repository = $this->createMock(RosteringImportRepository::class);
         $fileStorage = $this->createMock(FileStorageInterface::class);
@@ -82,27 +79,23 @@ class RosteringImportStatusServiceTest extends TestCase
             ->willReturn($import);
 
         $resultFileUrlProvider
-            ->expects(self::once())
-            ->method('generate')
-            ->with($resolver->mergedOutputFileKey('ref-2'))
-            ->willReturn('http://merged-output');
+            ->expects(self::never())
+            ->method('generate');
 
         $principalPortalStatusClient
             ->expects(self::once())
             ->method('fetchStatus')
             ->with('ref-2')
-            ->willReturn(new RosteringImportStatus('ref-2', 'processed', 3, [], null));
+            ->willReturn(new RosteringImportStatus('ref-2', 'processed', 3, []));
 
         $statusMerger
             ->expects(self::once())
             ->method('merge')
-            ->willReturn(new RosteringImportStatus('ref-2', 'processed', 5, [], null));
+            ->willReturn(new RosteringImportStatus('ref-2', 'processed', 5, []));
 
         $resultFileMerger
-            ->expects(self::once())
-            ->method('getOrCreateMergedOutputFileKey')
-            ->with('ref-2')
-            ->willReturn($resolver->mergedOutputFileKey('ref-2'));
+            ->expects(self::never())
+            ->method('getOrCreateMergedOutputFileKey');
 
         $subject = $this->createSubject(
             $repository,
@@ -119,7 +112,99 @@ class RosteringImportStatusServiceTest extends TestCase
 
         self::assertInstanceOf(RosteringImportStatus::class, $status);
         self::assertSame('processed', $status->getStatus());
-        self::assertSame('http://merged-output', $status->getResultFileUrl());
+    }
+
+    public function testItReturnsLocalDownloadUrlWhenProcessedAndIntegrationIsDisabled(): void
+    {
+        $repository = $this->createMock(RosteringImportRepository::class);
+        $fileStorage = $this->createMock(FileStorageInterface::class);
+        $resultFileUrlProvider = $this->createMock(ResultFileUrlProviderInterface::class);
+        $principalPortalStatusClient = $this->createMock(PrincipalPortalStatusClientInterface::class);
+        $statusMerger = $this->createMock(RosteringImportStatusMerger::class);
+        $resultFileMerger = $this->createMock(RosteringResultFileMerger::class);
+        $resolver = new RosteringFileKeyResolver();
+
+        $repository
+            ->expects(self::once())
+            ->method('findOneBy')
+            ->with(['referenceId' => 'ref-3'])
+            ->willReturn($this->createProcessedImport('ref-3'));
+
+        $resultFileUrlProvider
+            ->expects(self::once())
+            ->method('generate')
+            ->with($resolver->outputFileKey('ref-3'))
+            ->willReturn('http://local-output');
+
+        $principalPortalStatusClient
+            ->expects(self::never())
+            ->method('fetchStatus');
+
+        $subject = $this->createSubject(
+            $repository,
+            $fileStorage,
+            $resolver,
+            $resultFileUrlProvider,
+            $principalPortalStatusClient,
+            $statusMerger,
+            $resultFileMerger,
+            false
+        );
+
+        self::assertSame('http://local-output', $subject->getDownloadUrl('ref-3'));
+    }
+
+    public function testItReturnsMergedDownloadUrlWhenProcessedAndIntegrationIsEnabled(): void
+    {
+        $repository = $this->createMock(RosteringImportRepository::class);
+        $fileStorage = $this->createMock(FileStorageInterface::class);
+        $resultFileUrlProvider = $this->createMock(ResultFileUrlProviderInterface::class);
+        $principalPortalStatusClient = $this->createMock(PrincipalPortalStatusClientInterface::class);
+        $statusMerger = $this->createMock(RosteringImportStatusMerger::class);
+        $resultFileMerger = $this->createMock(RosteringResultFileMerger::class);
+        $resolver = new RosteringFileKeyResolver();
+
+        $repository
+            ->expects(self::once())
+            ->method('findOneBy')
+            ->with(['referenceId' => 'ref-4'])
+            ->willReturn($this->createProcessedImport('ref-4'));
+
+        $principalPortalStatusClient
+            ->expects(self::once())
+            ->method('fetchStatus')
+            ->with('ref-4')
+            ->willReturn(new RosteringImportStatus('ref-4', 'processed', 3, []));
+
+        $statusMerger
+            ->expects(self::once())
+            ->method('merge')
+            ->willReturn(new RosteringImportStatus('ref-4', 'processed', 5, []));
+
+        $resultFileMerger
+            ->expects(self::once())
+            ->method('getOrCreateMergedOutputFileKey')
+            ->with('ref-4')
+            ->willReturn($resolver->mergedOutputFileKey('ref-4'));
+
+        $resultFileUrlProvider
+            ->expects(self::once())
+            ->method('generate')
+            ->with($resolver->mergedOutputFileKey('ref-4'))
+            ->willReturn('http://merged-output');
+
+        $subject = $this->createSubject(
+            $repository,
+            $fileStorage,
+            $resolver,
+            $resultFileUrlProvider,
+            $principalPortalStatusClient,
+            $statusMerger,
+            $resultFileMerger,
+            true
+        );
+
+        self::assertSame('http://merged-output', $subject->getDownloadUrl('ref-4'));
     }
 
     private function createProcessedImport(string $referenceId): RosteringImport

--- a/tests/Unit/Service/Rostering/RosteringImportStatusServiceTest.php
+++ b/tests/Unit/Service/Rostering/RosteringImportStatusServiceTest.php
@@ -181,6 +181,14 @@ class RosteringImportStatusServiceTest extends TestCase
             ->method('merge')
             ->willReturn(new RosteringImportStatus('ref-4', 'processed', 5, []));
 
+        $fileStorage
+            ->expects(self::exactly(2))
+            ->method('exists')
+            ->willReturnMap([
+                [$resolver->outputFileKey('ref-4'), true],
+                [$resolver->principalPortalOutputFileKey('ref-4'), true],
+            ]);
+
         $resultFileMerger
             ->expects(self::once())
             ->method('getOrCreateMergedOutputFileKey')
@@ -205,6 +213,61 @@ class RosteringImportStatusServiceTest extends TestCase
         );
 
         self::assertSame('http://merged-output', $subject->getDownloadUrl('ref-4'));
+    }
+
+    public function testItReturnsNullWhenPrincipalPortalOutputIsNotReady(): void
+    {
+        $repository = $this->createMock(RosteringImportRepository::class);
+        $fileStorage = $this->createMock(FileStorageInterface::class);
+        $resultFileUrlProvider = $this->createMock(ResultFileUrlProviderInterface::class);
+        $principalPortalStatusClient = $this->createMock(PrincipalPortalStatusClientInterface::class);
+        $statusMerger = $this->createMock(RosteringImportStatusMerger::class);
+        $resultFileMerger = $this->createMock(RosteringResultFileMerger::class);
+        $resolver = new RosteringFileKeyResolver();
+
+        $repository
+            ->expects(self::once())
+            ->method('findOneBy')
+            ->with(['referenceId' => 'ref-5'])
+            ->willReturn($this->createProcessedImport('ref-5'));
+
+        $principalPortalStatusClient
+            ->expects(self::once())
+            ->method('fetchStatus')
+            ->with('ref-5')
+            ->willReturn(new RosteringImportStatus('ref-5', 'processed', 3, []));
+
+        $statusMerger
+            ->expects(self::once())
+            ->method('merge')
+            ->willReturn(new RosteringImportStatus('ref-5', 'processed', 5, []));
+
+        $fileStorage
+            ->expects(self::once())
+            ->method('exists')
+            ->with($resolver->outputFileKey('ref-5'))
+            ->willReturn(false);
+
+        $resultFileMerger
+            ->expects(self::never())
+            ->method('getOrCreateMergedOutputFileKey');
+
+        $resultFileUrlProvider
+            ->expects(self::never())
+            ->method('generate');
+
+        $subject = $this->createSubject(
+            $repository,
+            $fileStorage,
+            $resolver,
+            $resultFileUrlProvider,
+            $principalPortalStatusClient,
+            $statusMerger,
+            $resultFileMerger,
+            true
+        );
+
+        self::assertNull($subject->getDownloadUrl('ref-5'));
     }
 
     private function createProcessedImport(string $referenceId): RosteringImport


### PR DESCRIPTION
## Summary
Split rostering API responsibilities:
- `GET /api/status/{referenceId}` now returns only import status data.
- Signed download URL is now returned only by `GET /api/download/{referenceId}`.

## Why
Status endpoint should describe processing state only.
Download URL generation is a separate concern and should live in a dedicated endpoint.

## Changes
- Removed signed URL from status payload DTO/serialization.
- Added new download endpoint:
  - `GET /api/download/{referenceId}`
  - response: `{ "signedUrl": "..." }`
- Added API-key security coverage for `/api/download`.
- Added domain exception handling for download URL resolution:
  - service throws `RosteringStatusException`
  - controller maps to `BadRequestHttpException` with consistent message.
- Added/updated unit tests for status and download controllers.

## API Contract
Status response:
```json
{
  "result": {
    "status": "processed",
    "fileLine": 1,
    "messages": []
  }
}