### PR TITLE
refactor(upload): use RosteringFileKeyResolver in UploadFileService a…

### DIFF
--- a/src/Service/Upload/UploadFileService.php
+++ b/src/Service/Upload/UploadFileService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OAT\SimpleRoster\Service\Upload;
 
 use OAT\SimpleRoster\Message\RosteringFileUploadedMessage;
+use OAT\SimpleRoster\Service\Rostering\RosteringFileKeyResolver;
 use Ramsey\Uuid\Uuid;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -16,6 +17,7 @@ class UploadFileService
     public function __construct(
         private readonly UploadedFileValidator $validator,
         private readonly FileStorageInterface $fileStorage,
+        private readonly RosteringFileKeyResolver $fileKeyResolver,
         private readonly MessageBusInterface $messageBus
     ) {
     }
@@ -28,7 +30,7 @@ class UploadFileService
         $this->validator->validate($file);
 
         $referenceId = Uuid::uuid4()->toString();
-        $storageKey = $this->buildStorageKey($referenceId);
+        $storageKey = $this->fileKeyResolver->inputFileKey($referenceId);
 
         $this->fileStorage->store(
             $file,
@@ -42,10 +44,5 @@ class UploadFileService
             'message' => self::UPLOAD_SUCCESS_MESSAGE,
             'referenceId' => $referenceId,
         ];
-    }
-
-    private function buildStorageKey(string $referenceId): string
-    {
-        return sprintf('%s/input.csv', $referenceId);
     }
 }

--- a/tests/Functional/Action/Upload/UploadFileActionTest.php
+++ b/tests/Functional/Action/Upload/UploadFileActionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OAT\SimpleRoster\Tests\Functional\Action\Upload;
 
+use OAT\SimpleRoster\Service\Rostering\RosteringFileKeyResolver;
 use OAT\SimpleRoster\Service\Upload\FileStorageInterface;
 use OAT\SimpleRoster\Tests\AppWebTestCase;
 use OAT\SimpleRoster\Tests\Traits\DatabaseTestingTrait;
@@ -79,6 +80,8 @@ class UploadFileActionTest extends AppWebTestCase
 
     public function testItUploadsFileAndReturnsReferenceId(): void
     {
+        $keyResolver = new RosteringFileKeyResolver();
+
         /** @var FileStorageInterface&MockObject $storage */
         $storage = $this->createMock(FileStorageInterface::class);
 
@@ -120,10 +123,7 @@ class UploadFileActionTest extends AppWebTestCase
         self::assertSame('File uploaded', $decodedResponse['result']['message']);
         self::assertMatchesRegularExpression('#^[0-9a-f-]{36}$#', $decodedResponse['result']['referenceId']);
 
-        self::assertSame(
-            $decodedResponse['result']['referenceId'] . '/input.csv',
-            $captured['key']
-        );
+        self::assertSame($keyResolver->inputFileKey($decodedResponse['result']['referenceId']), $captured['key']);
         self::assertSame($decodedResponse['result']['referenceId'], $captured['metadata']['referenceId'] ?? null);
     }
 

--- a/tests/Unit/Service/Upload/UploadFileServiceTest.php
+++ b/tests/Unit/Service/Upload/UploadFileServiceTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OAT\SimpleRoster\Tests\Unit\Service\Upload;
 
 use OAT\SimpleRoster\Message\RosteringFileUploadedMessage;
+use OAT\SimpleRoster\Service\Rostering\RosteringFileKeyResolver;
 use OAT\SimpleRoster\Service\Upload\FileStorageInterface;
 use OAT\SimpleRoster\Service\Upload\UploadedFileValidator;
 use OAT\SimpleRoster\Service\Upload\UploadFileService;
@@ -30,9 +31,10 @@ class UploadFileServiceTest extends TestCase
         );
 
         $storage = $this->createMock(FileStorageInterface::class);
+        $resolver = new RosteringFileKeyResolver();
         $bus = $this->createMock(MessageBusInterface::class);
 
-        $service = new UploadFileService($validator, $storage, $bus);
+        $service = new UploadFileService($validator, $storage, $resolver, $bus);
 
         $file = $this->createUploadedFile('test.csv', 'a,b');
 


### PR DESCRIPTION
Refactor: Use RosteringFileKeyResolver in UploadFileService and align upload tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved file upload storage key handling for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->