### PR TITLE
feat: add swagger UI and OpenAPI spec endpoint

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -25,6 +25,10 @@ security:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
 
+        api_docs:
+            pattern: '^%app.route_prefix%/v1/docs/openapi\.yaml$'
+            security: false
+
         api_key:
             pattern: '^%app.route_prefix%/v1/(bulk-create-users|bulk|line-items|upload|status|download)(?:$|/)'
             provider: app_user_provider

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -79,6 +79,11 @@ getRosteringImportDownload:
   methods: GET
   defaults: { _controller: OAT\SimpleRoster\Action\RosteringImport\GetRosteringImportDownloadAction }
 
+getOpenApiSpec:
+  path: '%app.route_prefix%/v1/docs/openapi.yaml'
+  methods: GET
+  defaults: { _controller: OAT\SimpleRoster\Action\Documentation\GetOpenApiSpecAction }
+
 listLtiInstances:
   path: '%app.route_prefix%/v1/lti-instances'
   methods: GET

--- a/public/swagger/index.html
+++ b/public/swagger/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Simple Roster API Docs</title>
+    <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css" />
+</head>
+<body>
+<div id="swagger-ui"></div>
+<script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
+<script>
+    window.ui = SwaggerUIBundle({
+        url: '/api/v1/docs/openapi.yaml',
+        dom_id: '#swagger-ui',
+        deepLinking: true,
+        presets: [SwaggerUIBundle.presets.apis],
+    });
+</script>
+</body>
+</html>
+

--- a/src/Action/Documentation/GetOpenApiSpecAction.php
+++ b/src/Action/Documentation/GetOpenApiSpecAction.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OAT\SimpleRoster\Action\Documentation;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class GetOpenApiSpecAction
+{
+    public function __construct(
+        private readonly string $projectDir
+    ) {
+    }
+
+    public function __invoke(): Response
+    {
+        $specPath = sprintf('%s/openapi/api_v1.yml', rtrim($this->projectDir, '/'));
+
+        if (!is_file($specPath) || !is_readable($specPath)) {
+            throw new NotFoundHttpException('OpenAPI specification file was not found.');
+        }
+
+        $content = file_get_contents($specPath);
+        if ($content === false) {
+            throw new NotFoundHttpException('Unable to read OpenAPI specification file.');
+        }
+
+        return new Response(
+            $content,
+            Response::HTTP_OK,
+            ['Content-Type' => 'application/yaml; charset=utf-8']
+        );
+    }
+}
+


### PR DESCRIPTION
## Summary
This PR enables Swagger/OpenAPI access in Simple Roster.

## Changes
- Added Swagger UI static page:
  - `/swagger/index.html`
- Added OpenAPI spec endpoint:
  - `GET /api/v1/docs/openapi.yaml`
  - serves `openapi/api_v1.yml` directly from the app
- Added route registration for the docs endpoint.
- Updated security configuration to allow public access to the OpenAPI endpoint used by Swagger UI.

## Result
Simple Roster now exposes browsable API docs locally using the existing OpenAPI spec.

## Local URLs
- Swagger UI: `/swagger/index.html`
- OpenAPI YAML: `/api/v1/docs/openapi.yaml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Interactive API documentation interface with Swagger UI is now available
  * OpenAPI specification endpoint is publicly accessible without authentication
  * Users can explore API endpoints and view schema definitions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->