### PR TITLE
fix(upload): enforce max records correctly and report actual overflow…

### DIFF
--- a/src/Service/Upload/UploadedFileValidator.php
+++ b/src/Service/Upload/UploadedFileValidator.php
@@ -90,12 +90,12 @@ class UploadedFileValidator
                     continue;
                 }
 
-                ++$recordCount;
-                if ($recordCount + 1 > $this->allowedUploadedFileMaxRecords) {
+                $currentRecordCount = $recordCount + 1;
+                if ($currentRecordCount > $this->allowedUploadedFileMaxRecords) {
                     throw new UploadedFileValidationException(
                         sprintf(
                             'File records count "%d" exceeds maximum allowed records of "%d".',
-                            $recordCount,
+                            $currentRecordCount,
                             $this->allowedUploadedFileMaxRecords
                         )
                     );
@@ -111,6 +111,8 @@ class UploadedFileValidator
                         )
                     );
                 }
+
+                ++$recordCount;
             }
         } catch (SyntaxError $exception) {
             throw new UploadedFileValidationException('Uploaded file cannot be parsed as valid CSV.', 0, $exception);

--- a/tests/Unit/Service/Upload/UploadedFileValidatorTest.php
+++ b/tests/Unit/Service/Upload/UploadedFileValidatorTest.php
@@ -71,17 +71,17 @@ class UploadedFileValidatorTest extends TestCase
     public function testItRejectsTooManyRecords(): void
     {
         $validator = $this->createValidator(1024, 2);
-        $file = $this->createUploadedFile('test.csv', "col1,col2\na,b\nc,d");
+        $file = $this->createUploadedFile('test.csv', "col1,col2\na,b\nc,d\ne,f");
 
         $this->expectException(UploadedFileValidationException::class);
-        $this->expectExceptionMessage('File records count "2" exceeds maximum allowed records of "2".');
+        $this->expectExceptionMessage('File records count "3" exceeds maximum allowed records of "2".');
 
         $validator->validate($file);
     }
 
     public function testItAcceptsWhenRecordsCountEqualsConfiguredLimit(): void
     {
-        $validator = $this->createValidator(1024, 3);
+        $validator = $this->createValidator(1024, 2);
         $file = $this->createUploadedFile('test.csv', "col1,col2\na,b\nc,d");
 
         $validator->validate($file);


### PR DESCRIPTION
## Summary
This PR fixes CSV max-record validation in upload flow to correctly allow exactly `N` data rows (excluding header) when the limit is set to `N`.

## What was wrong
The previous validation used `$recordCount + 1` in the condition but reported `$recordCount` in the error message.  
This could produce a misleading message like:

`File records count "10000" exceeds maximum allowed records of "10000"`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced CSV file upload validation to accurately report the actual record count when files exceed the configured maximum record limit. Error messages now reflect precise counts for improved troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->