### PR TITLE
feat: allow upload zipped CSVs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### Added
 - Moved configuration files to a single oneup_flysystem.yaml and reverted changes based on different address and s3 prefixes depending on environment
 - Added file upload endpoint with validation, forwarding, and messenger notification
-- Added pssibility to upload zipped CSVs
+- Added possibility to upload zipped CSVs
 
 ### Fixed
 - Updated Docker configuration by adding the missing `msgpack` dependency and fixing Traefik labels

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Added
 - Moved configuration files to a single oneup_flysystem.yaml and reverted changes based on different address and s3 prefixes depending on environment
 - Added file upload endpoint with validation, forwarding, and messenger notification
+- Added pssibility to upload zipped CSVs
 
 ### Fixed
 - Updated Docker configuration by adding the missing `msgpack` dependency and fixing Traefik labels

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
         "ext-openssl": "*",
         "ext-redis": "*",
         "ext-simplexml": "*",
+        "ext-zip": "*",
         "aws/aws-sdk-php": "^3.81",
         "blackfire/php-sdk": "^1.23",
         "doctrine/dbal": "^3.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "272325d14586061ce2b33ebac87a68db",
+    "content-hash": "dc41d16f064d0111e9ec5b204453951d",
     "packages": [
         {
             "name": "async-aws/core",
@@ -17127,7 +17127,8 @@
         "ext-json": "*",
         "ext-openssl": "*",
         "ext-redis": "*",
-        "ext-simplexml": "*"
+        "ext-simplexml": "*",
+        "ext-zip": "*"
     },
     "platform-dev": {
         "ext-intl": "*"

--- a/openapi/api_v1.yml
+++ b/openapi/api_v1.yml
@@ -995,7 +995,7 @@ components:
                 file:
                     type: string
                     format: binary
-                    description: The file to be uploaded.
+                    description: The CSV file to be uploaded, or a ZIP archive containing exactly one CSV file.
         Error:
             type: object
             properties:

--- a/src/Service/Upload/PreparedUploadedFile.php
+++ b/src/Service/Upload/PreparedUploadedFile.php
@@ -10,9 +10,8 @@ final readonly class PreparedUploadedFile
 {
     public function __construct(
         private UploadedFile $file,
-        private bool         $isTemporary = false
-    )
-    {
+        private bool $isTemporary = false
+    ) {
     }
 
     public function file(): UploadedFile

--- a/src/Service/Upload/PreparedUploadedFile.php
+++ b/src/Service/Upload/PreparedUploadedFile.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OAT\SimpleRoster\Service\Upload;
+
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
+final readonly class PreparedUploadedFile
+{
+    public function __construct(
+        private UploadedFile $file,
+        private bool         $isTemporary = false
+    )
+    {
+    }
+
+    public function file(): UploadedFile
+    {
+        return $this->file;
+    }
+
+    public function cleanup(): void
+    {
+        if ($this->isTemporary) {
+            @unlink($this->file->getPathname());
+        }
+    }
+}

--- a/src/Service/Upload/UploadFileService.php
+++ b/src/Service/Upload/UploadFileService.php
@@ -71,7 +71,7 @@ class UploadFileService
 
         $archive = new ZipArchive();
 
-        if (!$archive->open($file->getPathname())) {
+        if ($archive->open($file->getPathname()) !== true) {
             throw new UploadedFileValidationException('Unable to read uploaded ZIP file.');
         }
 

--- a/src/Service/Upload/UploadFileService.php
+++ b/src/Service/Upload/UploadFileService.php
@@ -6,13 +6,16 @@ namespace OAT\SimpleRoster\Service\Upload;
 
 use OAT\SimpleRoster\Message\RosteringFileUploadedMessage;
 use OAT\SimpleRoster\Service\Rostering\RosteringFileKeyResolver;
+use OAT\SimpleRoster\Service\Upload\Exception\UploadedFileValidationException;
 use Ramsey\Uuid\Uuid;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\Messenger\MessageBusInterface;
+use ZipArchive;
 
 class UploadFileService
 {
     private const UPLOAD_SUCCESS_MESSAGE = 'File uploaded';
+    private const ZIP_FILE_EXTENSION = 'zip';
 
     public function __construct(
         private readonly UploadedFileValidator $validator,
@@ -27,22 +30,86 @@ class UploadFileService
      */
     public function upload(UploadedFile $file): array
     {
-        $this->validator->validate($file);
+        $fileToProcess = $this->extractFileFromZipIfNeeded($file);
 
-        $referenceId = Uuid::uuid4()->toString();
-        $storageKey = $this->fileKeyResolver->inputFileKey($referenceId);
+        try {
+            $this->validator->validate($fileToProcess);
 
-        $this->fileStorage->store(
-            $file,
-            $storageKey,
-            ['referenceId' => $referenceId]
-        );
+            $referenceId = Uuid::uuid7()->toString();
+            $storageKey = $this->fileKeyResolver->inputFileKey($referenceId);
 
-        $this->messageBus->dispatch(new RosteringFileUploadedMessage($referenceId));
+            $this->fileStorage->store(
+                $fileToProcess,
+                $storageKey,
+                ['referenceId' => $referenceId]
+            );
 
-        return [
-            'message' => self::UPLOAD_SUCCESS_MESSAGE,
-            'referenceId' => $referenceId,
-        ];
+            $this->messageBus->dispatch(new RosteringFileUploadedMessage($referenceId));
+
+            return [
+                'message' => self::UPLOAD_SUCCESS_MESSAGE,
+                'referenceId' => $referenceId,
+            ];
+        } finally {
+            if ($fileToProcess !== $file) {
+                @unlink($fileToProcess->getPathname());
+            }
+        }
+    }
+
+    private function extractFileFromZipIfNeeded(UploadedFile $file): UploadedFile
+    {
+        $extension = strtolower(trim($file->getClientOriginalExtension()));
+
+        if ($extension !== self::ZIP_FILE_EXTENSION) {
+            return $file;
+        }
+
+        if (!class_exists(ZipArchive::class)) {
+            throw new UploadedFileValidationException('ZIP file support is not available.');
+        }
+
+        $archive = new ZipArchive();
+
+        if (!$archive->open($file->getPathname())) {
+            throw new UploadedFileValidationException('Unable to read uploaded ZIP file.');
+        }
+
+        try {
+            $fileIndexes = [];
+
+            for ($index = 0; $index < $archive->numFiles; ++$index) {
+                $name = $archive->getNameIndex($index);
+
+                if (!is_string($name) || $name === '' || str_ends_with($name, '/')) {
+                    continue;
+                }
+
+                $fileIndexes[] = $index;
+            }
+
+            if (count($fileIndexes) !== 1) {
+                throw new UploadedFileValidationException('ZIP archive must contain exactly one file.');
+            }
+
+            $fileIndex = $fileIndexes[0];
+            $content = $archive->getFromIndex($fileIndex);
+
+            if (!is_string($content)) {
+                throw new UploadedFileValidationException('Unable to extract file from uploaded ZIP archive.');
+            }
+
+            $extractedPath = tempnam(sys_get_temp_dir(), 'upload_zip_');
+            if (!is_string($extractedPath) || file_put_contents($extractedPath, $content) === false) {
+                throw new UploadedFileValidationException('Unable to prepare extracted ZIP file for processing.');
+            }
+
+            $name = (string) $archive->getNameIndex($fileIndex);
+            $originalName = basename($name);
+
+            return new UploadedFile($extractedPath, $originalName, null, null, true);
+        } finally {
+            $archive->close();
+        }
     }
 }

--- a/src/Service/Upload/UploadFileService.php
+++ b/src/Service/Upload/UploadFileService.php
@@ -6,19 +6,17 @@ namespace OAT\SimpleRoster\Service\Upload;
 
 use OAT\SimpleRoster\Message\RosteringFileUploadedMessage;
 use OAT\SimpleRoster\Service\Rostering\RosteringFileKeyResolver;
-use OAT\SimpleRoster\Service\Upload\Exception\UploadedFileValidationException;
 use Ramsey\Uuid\Uuid;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\Messenger\MessageBusInterface;
-use ZipArchive;
 
 class UploadFileService
 {
-    private const UPLOAD_SUCCESS_MESSAGE = 'File uploaded';
-    private const ZIP_FILE_EXTENSION = 'zip';
+    private const string UPLOAD_SUCCESS_MESSAGE = 'File uploaded';
 
     public function __construct(
         private readonly UploadedFileValidator $validator,
+        private readonly ZippedCsvExtractor $zippedCsvExtractor,
         private readonly FileStorageInterface $fileStorage,
         private readonly RosteringFileKeyResolver $fileKeyResolver,
         private readonly MessageBusInterface $messageBus
@@ -30,12 +28,13 @@ class UploadFileService
      */
     public function upload(UploadedFile $file): array
     {
-        $fileToProcess = $this->extractFileFromZipIfNeeded($file);
+        $preparedFile = $this->zippedCsvExtractor->prepare($file);
+        $fileToProcess = $preparedFile->file();
 
         try {
             $this->validator->validate($fileToProcess);
 
-            $referenceId = Uuid::uuid7()->toString();
+            $referenceId = Uuid::uuid4()->toString();
             $storageKey = $this->fileKeyResolver->inputFileKey($referenceId);
 
             $this->fileStorage->store(
@@ -51,65 +50,7 @@ class UploadFileService
                 'referenceId' => $referenceId,
             ];
         } finally {
-            if ($fileToProcess !== $file) {
-                @unlink($fileToProcess->getPathname());
-            }
-        }
-    }
-
-    private function extractFileFromZipIfNeeded(UploadedFile $file): UploadedFile
-    {
-        $extension = strtolower(trim($file->getClientOriginalExtension()));
-
-        if ($extension !== self::ZIP_FILE_EXTENSION) {
-            return $file;
-        }
-
-        if (!class_exists(ZipArchive::class)) {
-            throw new UploadedFileValidationException('ZIP file support is not available.');
-        }
-
-        $archive = new ZipArchive();
-
-        if ($archive->open($file->getPathname()) !== true) {
-            throw new UploadedFileValidationException('Unable to read uploaded ZIP file.');
-        }
-
-        try {
-            $fileIndexes = [];
-
-            for ($index = 0; $index < $archive->numFiles; ++$index) {
-                $name = $archive->getNameIndex($index);
-
-                if (!is_string($name) || $name === '' || str_ends_with($name, '/')) {
-                    continue;
-                }
-
-                $fileIndexes[] = $index;
-            }
-
-            if (count($fileIndexes) !== 1) {
-                throw new UploadedFileValidationException('ZIP archive must contain exactly one file.');
-            }
-
-            $fileIndex = $fileIndexes[0];
-            $content = $archive->getFromIndex($fileIndex);
-
-            if (!is_string($content)) {
-                throw new UploadedFileValidationException('Unable to extract file from uploaded ZIP archive.');
-            }
-
-            $extractedPath = tempnam(sys_get_temp_dir(), 'upload_zip_');
-            if (!is_string($extractedPath) || file_put_contents($extractedPath, $content) === false) {
-                throw new UploadedFileValidationException('Unable to prepare extracted ZIP file for processing.');
-            }
-
-            $name = (string) $archive->getNameIndex($fileIndex);
-            $originalName = basename($name);
-
-            return new UploadedFile($extractedPath, $originalName, null, null, true);
-        } finally {
-            $archive->close();
+            $preparedFile->cleanup();
         }
     }
 }

--- a/src/Service/Upload/UploadedFileValidator.php
+++ b/src/Service/Upload/UploadedFileValidator.php
@@ -12,7 +12,7 @@ use Throwable;
 
 class UploadedFileValidator
 {
-    private const ALLOWED_FILE_EXTENSION = 'csv';
+    private const string ALLOWED_FILE_EXTENSION = 'csv';
 
     public function __construct(
         private readonly int $allowedUploadedFileMaxSize,

--- a/src/Service/Upload/UploadedFileValidator.php
+++ b/src/Service/Upload/UploadedFileValidator.php
@@ -60,6 +60,11 @@ class UploadedFileValidator
         $this->validateCsvStructure($file);
     }
 
+    public function getAllowedUploadedFileMaxSize(): int
+    {
+        return $this->allowedUploadedFileMaxSize;
+    }
+
     private function validateCsvStructure(UploadedFile $file): void
     {
         try {

--- a/src/Service/Upload/ZippedCsvExtractor.php
+++ b/src/Service/Upload/ZippedCsvExtractor.php
@@ -87,10 +87,10 @@ final class ZippedCsvExtractor
                     new UploadedFile($extractedPath, $originalName, null, null, true),
                     true
                 );
-            } catch (\Throwable $exception) {
+            } catch (\Throwable $throwable) {
                 @unlink($extractedPath);
 
-                throw $exception;
+                throw $throwable;
             }
         } finally {
             $archive->close();

--- a/src/Service/Upload/ZippedCsvExtractor.php
+++ b/src/Service/Upload/ZippedCsvExtractor.php
@@ -87,7 +87,7 @@ final class ZippedCsvExtractor
                     new UploadedFile($extractedPath, $originalName, null, null, true),
                     true
                 );
-            } catch (UploadedFileValidationException $exception) {
+            } catch (\Throwable $exception) {
                 @unlink($extractedPath);
 
                 throw $exception;

--- a/src/Service/Upload/ZippedCsvExtractor.php
+++ b/src/Service/Upload/ZippedCsvExtractor.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OAT\SimpleRoster\Service\Upload;
+
+use OAT\SimpleRoster\Service\Upload\Exception\UploadedFileValidationException;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use ZipArchive;
+
+final class ZippedCsvExtractor
+{
+    private const string ZIP_FILE_EXTENSION = 'zip';
+    private const int ZIP_READ_CHUNK_SIZE = 8192;
+
+    public function __construct(
+        private readonly UploadedFileValidator $validator
+    ) {
+    }
+
+    public function prepare(UploadedFile $file): PreparedUploadedFile
+    {
+        $extension = strtolower(trim($file->getClientOriginalExtension()));
+
+        if ($extension !== self::ZIP_FILE_EXTENSION) {
+            return new PreparedUploadedFile($file);
+        }
+
+        if (!class_exists(ZipArchive::class)) {
+            throw new UploadedFileValidationException('ZIP file support is not available.');
+        }
+
+        $archive = new ZipArchive();
+
+        if ($archive->open($file->getPathname()) !== true) {
+            throw new UploadedFileValidationException('Unable to read uploaded ZIP file.');
+        }
+
+        try {
+            $fileIndexes = [];
+
+            for ($index = 0; $index < $archive->numFiles; ++$index) {
+                $name = $archive->getNameIndex($index);
+
+                if (!is_string($name) || $name === '' || str_ends_with($name, '/')) {
+                    continue;
+                }
+
+                $fileIndexes[] = $index;
+            }
+
+            if (count($fileIndexes) !== 1) {
+                throw new UploadedFileValidationException('ZIP archive must contain exactly one file.');
+            }
+
+            $fileIndex = $fileIndexes[0];
+            $stat = $archive->statIndex($fileIndex);
+            $entrySize = $stat['size'] ?? null;
+
+            if (!is_int($entrySize)) {
+                throw new UploadedFileValidationException('Unable to determine extracted ZIP file size.');
+            }
+
+            $maxSize = $this->validator->getAllowedUploadedFileMaxSize();
+            if ($entrySize > $maxSize) {
+                throw new UploadedFileValidationException(
+                    sprintf(
+                        'File size "%d" exceeds maximum allowed size of "%d".',
+                        $entrySize,
+                        $maxSize
+                    )
+                );
+            }
+
+            $extractedPath = tempnam(sys_get_temp_dir(), 'upload_zip_');
+            if (!is_string($extractedPath)) {
+                throw new UploadedFileValidationException('Unable to prepare extracted ZIP file for processing.');
+            }
+
+            try {
+                $this->extractArchiveEntryToPath($archive, $fileIndex, $extractedPath);
+
+                $name = (string) $archive->getNameIndex($fileIndex);
+                $originalName = basename($name);
+
+                return new PreparedUploadedFile(
+                    new UploadedFile($extractedPath, $originalName, null, null, true),
+                    true
+                );
+            } catch (UploadedFileValidationException $exception) {
+                @unlink($extractedPath);
+
+                throw $exception;
+            }
+        } finally {
+            $archive->close();
+        }
+    }
+
+    private function extractArchiveEntryToPath(ZipArchive $archive, int $fileIndex, string $extractedPath): void
+    {
+        $name = $archive->getNameIndex($fileIndex);
+        $inputStream = is_string($name) ? $archive->getStream($name) : false;
+        if (!is_resource($inputStream)) {
+            throw new UploadedFileValidationException('Unable to extract file from uploaded ZIP archive.');
+        }
+
+        $outputStream = @fopen($extractedPath, 'wb');
+        if (!is_resource($outputStream)) {
+            fclose($inputStream);
+
+            throw new UploadedFileValidationException('Unable to prepare extracted ZIP file for processing.');
+        }
+
+        try {
+            while (!feof($inputStream)) {
+                $chunk = fread($inputStream, self::ZIP_READ_CHUNK_SIZE);
+
+                if (!is_string($chunk)) {
+                    throw new UploadedFileValidationException('Unable to extract file from uploaded ZIP archive.');
+                }
+
+                if ($chunk === '') {
+                    continue;
+                }
+
+                if (fwrite($outputStream, $chunk) === false) {
+                    throw new UploadedFileValidationException('Unable to prepare extracted ZIP file for processing.');
+                }
+            }
+        } finally {
+            fclose($inputStream);
+            fclose($outputStream);
+        }
+    }
+}

--- a/tests/Functional/Action/Upload/UploadFileActionTest.php
+++ b/tests/Functional/Action/Upload/UploadFileActionTest.php
@@ -14,6 +14,7 @@ use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use ZipArchive;
 
 class UploadFileActionTest extends AppWebTestCase
 {
@@ -157,6 +158,97 @@ class UploadFileActionTest extends AppWebTestCase
         );
     }
 
+    public function testItUploadsSingleCsvFromZipAndReturnsReferenceId(): void
+    {
+        if (!class_exists(ZipArchive::class)) {
+            self::markTestSkipped('The zip extension is not installed.');
+        }
+
+        /** @var FileStorageInterface&MockObject $storage */
+        $storage = $this->createMock(FileStorageInterface::class);
+
+        $captured = ['content' => null, 'originalName' => null];
+
+        $storage
+            ->method('store')
+            ->willReturnCallback(static function (UploadedFile $file) use (&$captured): void {
+                $captured['content'] = file_get_contents($file->getPathname());
+                $captured['originalName'] = $file->getClientOriginalName();
+            });
+
+        self::getContainer()->set('test.file_storage', $storage);
+
+        $file = $this->createUploadedZip('test.zip', ['test.csv' => "a,b\nc,d"]);
+
+        $this->kernelBrowser->request(
+            Request::METHOD_POST,
+            '/api/v1/upload',
+            [],
+            ['file' => $file]
+        );
+
+        self::assertSame(
+            Response::HTTP_OK,
+            $this->kernelBrowser->getResponse()->getStatusCode(),
+            (string)$this->kernelBrowser->getResponse()->getContent()
+        );
+
+        $decodedResponse = json_decode(
+            $this->kernelBrowser->getResponse()->getContent(),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+
+        self::assertSame('File uploaded', $decodedResponse['result']['message']);
+        self::assertMatchesRegularExpression('#^[0-9a-f-]{36}$#', $decodedResponse['result']['referenceId']);
+        self::assertSame("a,b\nc,d", $captured['content']);
+        self::assertSame('test.csv', $captured['originalName']);
+    }
+
+    public function testItReturns400WhenZipContainsSeveralFiles(): void
+    {
+        if (!class_exists(ZipArchive::class)) {
+            self::markTestSkipped('The zip extension is not installed.');
+        }
+
+        /** @var FileStorageInterface&MockObject $storage */
+        $storage = $this->createMock(FileStorageInterface::class);
+
+        $storage
+            ->expects($this->never())
+            ->method('store');
+
+        self::getContainer()->set('test.file_storage', $storage);
+
+        $file = $this->createUploadedZip('test.zip', [
+            'one.csv' => 'a,b',
+            'two.csv' => 'c,d',
+        ]);
+
+        $this->kernelBrowser->request(
+            Request::METHOD_POST,
+            '/api/v1/upload',
+            [],
+            ['file' => $file]
+        );
+
+        self::assertSame(
+            Response::HTTP_BAD_REQUEST,
+            $this->kernelBrowser->getResponse()->getStatusCode(),
+            (string)$this->kernelBrowser->getResponse()->getContent()
+        );
+
+        $decodedResponse = json_decode(
+            $this->kernelBrowser->getResponse()->getContent(),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+
+        self::assertSame('ZIP archive must contain exactly one file.', $decodedResponse['error']['message']);
+    }
+
     private function createUploadedFile(string $originalName, string $content): UploadedFile
     {
         $tmpDir = sys_get_temp_dir();
@@ -164,5 +256,24 @@ class UploadFileActionTest extends AppWebTestCase
         file_put_contents($path, $content);
 
         return new UploadedFile($path, $originalName, 'text/csv', null, true);
+    }
+
+    /**
+     * @param array<string, string> $files
+     */
+    private function createUploadedZip(string $originalName, array $files): UploadedFile
+    {
+        $tmpDir = sys_get_temp_dir();
+        $path = $tmpDir . '/' . uniqid('upload_', true) . '_' . $originalName;
+        $zip = new ZipArchive();
+        $zip->open($path, ZipArchive::CREATE);
+
+        foreach ($files as $name => $content) {
+            $zip->addFromString($name, $content);
+        }
+
+        $zip->close();
+
+        return new UploadedFile($path, $originalName, 'application/zip', null, true);
     }
 }

--- a/tests/Unit/Service/Upload/UploadFileServiceTest.php
+++ b/tests/Unit/Service/Upload/UploadFileServiceTest.php
@@ -13,6 +13,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
+use ZipArchive;
 
 class UploadFileServiceTest extends TestCase
 {
@@ -66,11 +67,116 @@ class UploadFileServiceTest extends TestCase
         $this->assertMatchesRegularExpression('#^[0-9a-f-]{36}$#', $result['referenceId']);
     }
 
+    public function testItExtractsSingleCsvFromZipBeforeStoringFile(): void
+    {
+        if (!class_exists(ZipArchive::class)) {
+            $this->markTestSkipped('The zip extension is not installed.');
+        }
+
+        $validator = new UploadedFileValidator(
+            1024,
+            100,
+            self::CSV_DELIMITER,
+            self::CSV_ENCLOSURE,
+            self::CSV_ESCAPE
+        );
+
+        $storage = $this->createMock(FileStorageInterface::class);
+        $resolver = new RosteringFileKeyResolver();
+        $bus = $this->createMock(MessageBusInterface::class);
+
+        $service = new UploadFileService($validator, $storage, $resolver, $bus);
+
+        $file = $this->createUploadedZip('test.zip', ['roster.csv' => "a,b\nc,d"]);
+
+        $storage
+            ->expects($this->once())
+            ->method('store')
+            ->with(
+                $this->callback(static function (UploadedFile $storedFile) use ($file): bool {
+                    return $storedFile !== $file
+                        && $storedFile->getClientOriginalName() === 'roster.csv'
+                        && file_get_contents($storedFile->getPathname()) === "a,b\nc,d";
+                }),
+                $this->matchesRegularExpression('#^[0-9a-f-]{36}/input\.csv$#'),
+                $this->callback(static function (array $metadata): bool {
+                    return isset($metadata['referenceId']) && is_string($metadata['referenceId']) && $metadata['referenceId'] !== '';
+                })
+            );
+
+        $bus
+            ->expects($this->once())
+            ->method('dispatch')
+            ->willReturn(new Envelope(new RosteringFileUploadedMessage('ref')));
+
+        $result = $service->upload($file);
+
+        $this->assertSame('File uploaded', $result['message']);
+        $this->assertMatchesRegularExpression('#^[0-9a-f-]{36}$#', $result['referenceId']);
+    }
+
+    public function testItRejectsZipWithSeveralFiles(): void
+    {
+        if (!class_exists(ZipArchive::class)) {
+            $this->markTestSkipped('The zip extension is not installed.');
+        }
+
+        $validator = new UploadedFileValidator(
+            1024,
+            100,
+            self::CSV_DELIMITER,
+            self::CSV_ENCLOSURE,
+            self::CSV_ESCAPE
+        );
+
+        $storage = $this->createMock(FileStorageInterface::class);
+        $resolver = new RosteringFileKeyResolver();
+        $bus = $this->createMock(MessageBusInterface::class);
+
+        $service = new UploadFileService($validator, $storage, $resolver, $bus);
+
+        $file = $this->createUploadedZip('test.zip', [
+            'one.csv' => 'a,b',
+            'two.csv' => 'c,d',
+        ]);
+
+        $storage
+            ->expects($this->never())
+            ->method('store');
+
+        $bus
+            ->expects($this->never())
+            ->method('dispatch');
+
+        $this->expectExceptionMessage('ZIP archive must contain exactly one file.');
+
+        $service->upload($file);
+    }
+
     private function createUploadedFile(string $originalName, string $content): UploadedFile
     {
         $tmpDir = sys_get_temp_dir();
         $path = $tmpDir . '/' . uniqid('upload_', true) . '_' . $originalName;
         file_put_contents($path, $content);
+
+        return new UploadedFile($path, $originalName, null, null, true);
+    }
+
+    /**
+     * @param array<string, string> $files
+     */
+    private function createUploadedZip(string $originalName, array $files): UploadedFile
+    {
+        $tmpDir = sys_get_temp_dir();
+        $path = $tmpDir . '/' . uniqid('upload_', true) . '_' . $originalName;
+        $zip = new ZipArchive();
+        $zip->open($path, ZipArchive::CREATE);
+
+        foreach ($files as $name => $content) {
+            $zip->addFromString($name, $content);
+        }
+
+        $zip->close();
 
         return new UploadedFile($path, $originalName, null, null, true);
     }

--- a/tests/Unit/Service/Upload/UploadFileServiceTest.php
+++ b/tests/Unit/Service/Upload/UploadFileServiceTest.php
@@ -7,6 +7,7 @@ namespace OAT\SimpleRoster\Tests\Unit\Service\Upload;
 use OAT\SimpleRoster\Message\RosteringFileUploadedMessage;
 use OAT\SimpleRoster\Service\Rostering\RosteringFileKeyResolver;
 use OAT\SimpleRoster\Service\Upload\FileStorageInterface;
+use OAT\SimpleRoster\Service\Upload\Exception\UploadedFileValidationException;
 use OAT\SimpleRoster\Service\Upload\UploadedFileValidator;
 use OAT\SimpleRoster\Service\Upload\UploadFileService;
 use PHPUnit\Framework\TestCase;
@@ -46,7 +47,9 @@ class UploadFileServiceTest extends TestCase
                 $this->identicalTo($file),
                 $this->matchesRegularExpression('#^[0-9a-f-]{36}/input\.csv$#'),
                 $this->callback(static function (array $metadata): bool {
-                    return isset($metadata['referenceId']) && is_string($metadata['referenceId']) && $metadata['referenceId'] !== '';
+                    return isset($metadata['referenceId'])
+                        && is_string($metadata['referenceId'])
+                        && $metadata['referenceId'] !== '';
                 })
             );
 
@@ -100,7 +103,9 @@ class UploadFileServiceTest extends TestCase
                 }),
                 $this->matchesRegularExpression('#^[0-9a-f-]{36}/input\.csv$#'),
                 $this->callback(static function (array $metadata): bool {
-                    return isset($metadata['referenceId']) && is_string($metadata['referenceId']) && $metadata['referenceId'] !== '';
+                    return isset($metadata['referenceId'])
+                        && is_string($metadata['referenceId'])
+                        && $metadata['referenceId'] !== '';
                 })
             );
 
@@ -149,6 +154,42 @@ class UploadFileServiceTest extends TestCase
             ->method('dispatch');
 
         $this->expectExceptionMessage('ZIP archive must contain exactly one file.');
+
+        $service->upload($file);
+    }
+
+    public function testItRejectsUnreadableZipArchive(): void
+    {
+        if (!class_exists(ZipArchive::class)) {
+            $this->markTestSkipped('The zip extension is not installed.');
+        }
+
+        $validator = new UploadedFileValidator(
+            1024,
+            100,
+            self::CSV_DELIMITER,
+            self::CSV_ENCLOSURE,
+            self::CSV_ESCAPE
+        );
+
+        $storage = $this->createMock(FileStorageInterface::class);
+        $resolver = new RosteringFileKeyResolver();
+        $bus = $this->createMock(MessageBusInterface::class);
+
+        $service = new UploadFileService($validator, $storage, $resolver, $bus);
+
+        $file = $this->createUploadedFile('broken.zip', 'not a zip archive');
+
+        $storage
+            ->expects($this->never())
+            ->method('store');
+
+        $bus
+            ->expects($this->never())
+            ->method('dispatch');
+
+        $this->expectException(UploadedFileValidationException::class);
+        $this->expectExceptionMessage('Unable to read uploaded ZIP file.');
 
         $service->upload($file);
     }

--- a/tests/Unit/Service/Upload/UploadFileServiceTest.php
+++ b/tests/Unit/Service/Upload/UploadFileServiceTest.php
@@ -7,14 +7,13 @@ namespace OAT\SimpleRoster\Tests\Unit\Service\Upload;
 use OAT\SimpleRoster\Message\RosteringFileUploadedMessage;
 use OAT\SimpleRoster\Service\Rostering\RosteringFileKeyResolver;
 use OAT\SimpleRoster\Service\Upload\FileStorageInterface;
-use OAT\SimpleRoster\Service\Upload\Exception\UploadedFileValidationException;
+use OAT\SimpleRoster\Service\Upload\ZippedCsvExtractor;
 use OAT\SimpleRoster\Service\Upload\UploadedFileValidator;
 use OAT\SimpleRoster\Service\Upload\UploadFileService;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
-use ZipArchive;
 
 class UploadFileServiceTest extends TestCase
 {
@@ -35,8 +34,9 @@ class UploadFileServiceTest extends TestCase
         $storage = $this->createMock(FileStorageInterface::class);
         $resolver = new RosteringFileKeyResolver();
         $bus = $this->createMock(MessageBusInterface::class);
+        $extractor = new ZippedCsvExtractor($validator);
 
-        $service = new UploadFileService($validator, $storage, $resolver, $bus);
+        $service = new UploadFileService($validator, $extractor, $storage, $resolver, $bus);
 
         $file = $this->createUploadedFile('test.csv', 'a,b');
 
@@ -70,154 +70,11 @@ class UploadFileServiceTest extends TestCase
         $this->assertMatchesRegularExpression('#^[0-9a-f-]{36}$#', $result['referenceId']);
     }
 
-    public function testItExtractsSingleCsvFromZipBeforeStoringFile(): void
-    {
-        if (!class_exists(ZipArchive::class)) {
-            $this->markTestSkipped('The zip extension is not installed.');
-        }
-
-        $validator = new UploadedFileValidator(
-            1024,
-            100,
-            self::CSV_DELIMITER,
-            self::CSV_ENCLOSURE,
-            self::CSV_ESCAPE
-        );
-
-        $storage = $this->createMock(FileStorageInterface::class);
-        $resolver = new RosteringFileKeyResolver();
-        $bus = $this->createMock(MessageBusInterface::class);
-
-        $service = new UploadFileService($validator, $storage, $resolver, $bus);
-
-        $file = $this->createUploadedZip('test.zip', ['roster.csv' => "a,b\nc,d"]);
-
-        $storage
-            ->expects($this->once())
-            ->method('store')
-            ->with(
-                $this->callback(static function (UploadedFile $storedFile) use ($file): bool {
-                    return $storedFile !== $file
-                        && $storedFile->getClientOriginalName() === 'roster.csv'
-                        && file_get_contents($storedFile->getPathname()) === "a,b\nc,d";
-                }),
-                $this->matchesRegularExpression('#^[0-9a-f-]{36}/input\.csv$#'),
-                $this->callback(static function (array $metadata): bool {
-                    return isset($metadata['referenceId'])
-                        && is_string($metadata['referenceId'])
-                        && $metadata['referenceId'] !== '';
-                })
-            );
-
-        $bus
-            ->expects($this->once())
-            ->method('dispatch')
-            ->willReturn(new Envelope(new RosteringFileUploadedMessage('ref')));
-
-        $result = $service->upload($file);
-
-        $this->assertSame('File uploaded', $result['message']);
-        $this->assertMatchesRegularExpression('#^[0-9a-f-]{36}$#', $result['referenceId']);
-    }
-
-    public function testItRejectsZipWithSeveralFiles(): void
-    {
-        if (!class_exists(ZipArchive::class)) {
-            $this->markTestSkipped('The zip extension is not installed.');
-        }
-
-        $validator = new UploadedFileValidator(
-            1024,
-            100,
-            self::CSV_DELIMITER,
-            self::CSV_ENCLOSURE,
-            self::CSV_ESCAPE
-        );
-
-        $storage = $this->createMock(FileStorageInterface::class);
-        $resolver = new RosteringFileKeyResolver();
-        $bus = $this->createMock(MessageBusInterface::class);
-
-        $service = new UploadFileService($validator, $storage, $resolver, $bus);
-
-        $file = $this->createUploadedZip('test.zip', [
-            'one.csv' => 'a,b',
-            'two.csv' => 'c,d',
-        ]);
-
-        $storage
-            ->expects($this->never())
-            ->method('store');
-
-        $bus
-            ->expects($this->never())
-            ->method('dispatch');
-
-        $this->expectExceptionMessage('ZIP archive must contain exactly one file.');
-
-        $service->upload($file);
-    }
-
-    public function testItRejectsUnreadableZipArchive(): void
-    {
-        if (!class_exists(ZipArchive::class)) {
-            $this->markTestSkipped('The zip extension is not installed.');
-        }
-
-        $validator = new UploadedFileValidator(
-            1024,
-            100,
-            self::CSV_DELIMITER,
-            self::CSV_ENCLOSURE,
-            self::CSV_ESCAPE
-        );
-
-        $storage = $this->createMock(FileStorageInterface::class);
-        $resolver = new RosteringFileKeyResolver();
-        $bus = $this->createMock(MessageBusInterface::class);
-
-        $service = new UploadFileService($validator, $storage, $resolver, $bus);
-
-        $file = $this->createUploadedFile('broken.zip', 'not a zip archive');
-
-        $storage
-            ->expects($this->never())
-            ->method('store');
-
-        $bus
-            ->expects($this->never())
-            ->method('dispatch');
-
-        $this->expectException(UploadedFileValidationException::class);
-        $this->expectExceptionMessage('Unable to read uploaded ZIP file.');
-
-        $service->upload($file);
-    }
-
     private function createUploadedFile(string $originalName, string $content): UploadedFile
     {
         $tmpDir = sys_get_temp_dir();
         $path = $tmpDir . '/' . uniqid('upload_', true) . '_' . $originalName;
         file_put_contents($path, $content);
-
-        return new UploadedFile($path, $originalName, null, null, true);
-    }
-
-    /**
-     * @param array<string, string> $files
-     */
-    private function createUploadedZip(string $originalName, array $files): UploadedFile
-    {
-        $tmpDir = sys_get_temp_dir();
-        $path = $tmpDir . '/' . uniqid('upload_', true) . '_' . $originalName;
-        $zip = new ZipArchive();
-        $zip->open($path, ZipArchive::CREATE);
-
-        foreach ($files as $name => $content) {
-            $zip->addFromString($name, $content);
-        }
-
-        $zip->close();
 
         return new UploadedFile($path, $originalName, null, null, true);
     }

--- a/tests/Unit/Service/Upload/ZippedCsvExtractorTest.php
+++ b/tests/Unit/Service/Upload/ZippedCsvExtractorTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OAT\SimpleRoster\Tests\Unit\Service\Upload;
+
+use OAT\SimpleRoster\Service\Upload\Exception\UploadedFileValidationException;
+use OAT\SimpleRoster\Service\Upload\UploadedFileValidator;
+use OAT\SimpleRoster\Service\Upload\ZippedCsvExtractor;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use ZipArchive;
+
+class ZippedCsvExtractorTest extends TestCase
+{
+    private const CSV_DELIMITER = ',';
+    private const CSV_ENCLOSURE = '"';
+    private const CSV_ESCAPE = '\\';
+
+    public function testItReturnsOriginalFileWhenFileIsNotZip(): void
+    {
+        $validator = $this->createValidator(1024);
+        $extractor = new ZippedCsvExtractor($validator);
+        $file = $this->createUploadedFile('test.csv', 'a,b');
+
+        $preparedFile = $extractor->prepare($file);
+
+        $this->assertSame($file, $preparedFile->file());
+    }
+
+    public function testItExtractsSingleCsvFromZip(): void
+    {
+        if (!class_exists(ZipArchive::class)) {
+            $this->markTestSkipped('The zip extension is not installed.');
+        }
+
+        $validator = $this->createValidator(1024);
+        $extractor = new ZippedCsvExtractor($validator);
+        $file = $this->createUploadedZip('test.zip', ['roster.csv' => "a,b\nc,d"]);
+
+        $preparedFile = $extractor->prepare($file);
+
+        try {
+            $this->assertNotSame($file, $preparedFile->file());
+            $this->assertSame('roster.csv', $preparedFile->file()->getClientOriginalName());
+            $this->assertSame("a,b\nc,d", file_get_contents($preparedFile->file()->getPathname()));
+        } finally {
+            $preparedFile->cleanup();
+        }
+    }
+
+    public function testItRejectsZipWithSeveralFiles(): void
+    {
+        if (!class_exists(ZipArchive::class)) {
+            $this->markTestSkipped('The zip extension is not installed.');
+        }
+
+        $extractor = new ZippedCsvExtractor($this->createValidator(1024));
+        $file = $this->createUploadedZip('test.zip', [
+            'one.csv' => 'a,b',
+            'two.csv' => 'c,d',
+        ]);
+
+        $this->expectException(UploadedFileValidationException::class);
+        $this->expectExceptionMessage('ZIP archive must contain exactly one file.');
+
+        $extractor->prepare($file);
+    }
+
+    public function testItRejectsUnreadableZipArchive(): void
+    {
+        if (!class_exists(ZipArchive::class)) {
+            $this->markTestSkipped('The zip extension is not installed.');
+        }
+
+        $extractor = new ZippedCsvExtractor($this->createValidator(1024));
+        $file = $this->createUploadedFile('broken.zip', 'not a zip archive');
+
+        $this->expectException(UploadedFileValidationException::class);
+        $this->expectExceptionMessage('Unable to read uploaded ZIP file.');
+
+        $extractor->prepare($file);
+    }
+
+    public function testItRejectsZipEntryThatExceedsConfiguredMaxSize(): void
+    {
+        if (!class_exists(ZipArchive::class)) {
+            $this->markTestSkipped('The zip extension is not installed.');
+        }
+
+        $extractor = new ZippedCsvExtractor($this->createValidator(3));
+        $file = $this->createUploadedZip('oversized.zip', ['roster.csv' => '1234']);
+
+        $this->expectException(UploadedFileValidationException::class);
+        $this->expectExceptionMessage('File size "4" exceeds maximum allowed size of "3".');
+
+        $extractor->prepare($file);
+    }
+
+    private function createValidator(int $maxSize): UploadedFileValidator
+    {
+        return new UploadedFileValidator(
+            $maxSize,
+            100,
+            self::CSV_DELIMITER,
+            self::CSV_ENCLOSURE,
+            self::CSV_ESCAPE
+        );
+    }
+
+    private function createUploadedFile(string $originalName, string $content): UploadedFile
+    {
+        $tmpDir = sys_get_temp_dir();
+        $path = $tmpDir . '/' . uniqid('upload_', true) . '_' . $originalName;
+        file_put_contents($path, $content);
+
+        return new UploadedFile($path, $originalName, null, null, true);
+    }
+
+    /**
+     * @param array<string, string> $files
+     */
+    private function createUploadedZip(string $originalName, array $files): UploadedFile
+    {
+        $tmpDir = sys_get_temp_dir();
+        $path = $tmpDir . '/' . uniqid('upload_', true) . '_' . $originalName;
+        $zip = new ZipArchive();
+        $zip->open($path, ZipArchive::CREATE);
+
+        foreach ($files as $name => $content) {
+            $zip->addFromString($name, $content);
+        }
+
+        $zip->close();
+
+        return new UploadedFile($path, $originalName, null, null, true);
+    }
+}


### PR DESCRIPTION
Allow to upload compressed CSVs as AWS API Gateway has a limit 2Mb per file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support uploading a ZIP that contains exactly one CSV; the system extracts and processes the CSV. ZIPs with multiple files are rejected with a clear validation error and no file is stored.

* **Documentation**
  * API spec clarifies accepted upload formats: CSV or a ZIP containing a single CSV.

* **Chores**
  * PHP "zip" extension is now required.

* **Tests**
  * Added unit and functional tests for ZIP extraction, single-file acceptance, multi-file rejection, and related error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->