### PR TITLE
fix: log rostering row internal errors at error level

### DIFF
--- a/src/Service/Rostering/RosteringFileProcessor.php
+++ b/src/Service/Rostering/RosteringFileProcessor.php
@@ -243,7 +243,7 @@ class RosteringFileProcessor
             $resultRow[self::RESULT_ERROR_CODE] = self::ERROR_CODE_INTERNAL;
             $resultRow[self::RESULT_ERROR_MESSAGE] = self::ERROR_MESSAGE_INTERNAL;
 
-            $this->logger->warning(
+            $this->logger->error(
                 'Unexpected error while importing rostering row.',
                 ['exception' => $exception]
             );


### PR DESCRIPTION
## Summary
This PR makes a minimal logging adjustment for rostering row processing in both PP and SR.

## Change
- Changed log level from `warning` to `error` in `RosteringFileProcessor` for the `catch (Throwable)` branch that maps row processing to:
  - status `500`
  - error code `csv.import.internalError`

## Why
Internal row-processing failures should be visible as errors in production logs/monitoring, while keeping validation-related failures (`400`) unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error visibility by adjusting logging levels for unexpected exceptions encountered during processing operations, ensuring critical issues are properly flagged for monitoring and alert systems.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oat-sa/simple-roster/pull/326?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->