### PR TITLE
Feat(LSI-8100): replace classroomId with schoolId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+### Fixed
+- [LSI-8100](https://oat-sa.atlassian.net/browse/LSI-8100) Populated SR rostering `groupId` from `hierarchy_parentOrganizationId` instead of `hierarchy_orgnizationId`.
+
 ## 4.2.0 - 2026-05-28
 ### Added
 - [LSI-8076](https://oat-sa.atlassian.net/browse/LSI-8076) Allowed whitespace in rostering organization identifiers and aligned integration test expectations.

--- a/src/Service/Rostering/Dto/RosteringUserEntryDto.php
+++ b/src/Service/Rostering/Dto/RosteringUserEntryDto.php
@@ -9,7 +9,7 @@ final class RosteringUserEntryDto
     public function __construct(
         private readonly ?string $userUsername,
         private readonly ?string $userPassword,
-        private readonly ?string $userOrganizationId,
+        private readonly ?string $parentOrganizationId,
         private readonly ?string $sessionName,
         private readonly ?string $userLanguage,
         private readonly ?bool $userActive
@@ -20,7 +20,7 @@ final class RosteringUserEntryDto
     {
         return $this->userUsername !== null
             || $this->userPassword !== null
-            || $this->userOrganizationId !== null
+            || $this->parentOrganizationId !== null
             || $this->sessionName !== null
             || $this->userLanguage !== null
             || $this->userActive !== null;
@@ -36,9 +36,9 @@ final class RosteringUserEntryDto
         return $this->userPassword;
     }
 
-    public function getUserOrganizationId(): ?string
+    public function getParentOrganizationId(): ?string
     {
-        return $this->userOrganizationId;
+        return $this->parentOrganizationId;
     }
 
     public function getSessionName(): ?string

--- a/src/Service/Rostering/Dto/RosteringUserEntryDtoFactory.php
+++ b/src/Service/Rostering/Dto/RosteringUserEntryDtoFactory.php
@@ -19,14 +19,13 @@ final class RosteringUserEntryDtoFactory
     {
         $username = $this->fieldValueOrNull($values, RosteringUserRowValidator::FIELD_USER_USERNAME);
         $password = $this->fieldValueOrNull($values, RosteringUserRowValidator::FIELD_USER_PASSWORD);
-        $organizationId = $this->fieldValueOrNull($values, RosteringUserRowValidator::FIELD_USER_ORGANIZATION_ID);
+        $parentOrganizationId = $this->fieldValueOrNull($values, RosteringUserRowValidator::FIELD_HIERARCHY_PARENT_ORGANIZATION_ID);
         $sessionName = $this->fieldValueOrNull($values, RosteringUserRowValidator::FIELD_SESSION_NAME);
         $userLanguage = $this->fieldValueOrNull($values, RosteringUserRowValidator::FIELD_USER_LANGUAGE);
         $userActiveRaw = $this->fieldValueOrNull($values, RosteringUserRowValidator::FIELD_USER_ACTIVE);
         if (
             null === $username
             && null === $password
-            && null === $organizationId
             && null === $sessionName
             && null === $userLanguage
             && null === $userActiveRaw
@@ -36,8 +35,8 @@ final class RosteringUserEntryDtoFactory
 
         $this->rowValidator->validateUsername($username ?? '');
 
-        if (null !== $organizationId) {
-            $this->rowValidator->validateOrganizationId($organizationId);
+        if (null !== $parentOrganizationId) {
+            $this->rowValidator->validateParentOrganizationId($parentOrganizationId);
         }
 
         if (null !== $sessionName) {
@@ -49,7 +48,7 @@ final class RosteringUserEntryDtoFactory
         return new RosteringUserEntryDto(
             $username,
             $password,
-            $organizationId,
+            $parentOrganizationId,
             $sessionName,
             $userLanguage,
             $isUserActive

--- a/src/Service/Rostering/RosteringFileProcessor.php
+++ b/src/Service/Rostering/RosteringFileProcessor.php
@@ -262,7 +262,7 @@ class RosteringFileProcessor
         }
 
         $password = $entryDto->getUserPassword() ?? '';
-        $organizationId = $entryDto->getUserOrganizationId() ?? '';
+        $parentOrganizationId = $entryDto->getParentOrganizationId() ?? '';
         $sessionName = $entryDto->getSessionName() ?? '';
 
         $isUserActive = $entryDto->getUserActive();
@@ -281,7 +281,7 @@ class RosteringFileProcessor
         }
 
         $hasPassword = '' !== $password;
-        $hasOrganizationId = '' !== $organizationId;
+        $hasParentOrganizationId = '' !== $parentOrganizationId;
         $hasSessionName = '' !== $sessionName;
 
         if (null !== $userId) {
@@ -293,8 +293,8 @@ class RosteringFileProcessor
                 $fieldsToUpdate['password'] = $this->hashUserPassword($username, $password);
             }
 
-            if ($hasOrganizationId) {
-                $fieldsToUpdate['groupId'] = $organizationId;
+            if ($hasParentOrganizationId) {
+                $fieldsToUpdate['groupId'] = $parentOrganizationId;
             }
 
             $this->userRepository->updateForRostering($username, $fieldsToUpdate);
@@ -318,9 +318,12 @@ class RosteringFileProcessor
             );
         }
 
-        if (!$hasOrganizationId) {
+        if (!$hasParentOrganizationId) {
             throw new RosteringValidationException(
-                sprintf('Field "%s" is required for new user.', RosteringUserRowValidator::FIELD_USER_ORGANIZATION_ID)
+                sprintf(
+                    'Field "%s" is required for new user.',
+                    RosteringUserRowValidator::FIELD_HIERARCHY_PARENT_ORGANIZATION_ID
+                )
             );
         }
 
@@ -330,7 +333,7 @@ class RosteringFileProcessor
             );
         }
 
-        $createdUserId = $this->createUser($username, $password, $organizationId);
+        $createdUserId = $this->createUser($username, $password, $parentOrganizationId);
         $this->replaceUserAssignment($createdUserId, $sessionName);
         $this->userCacheSynchronizer->markForWarmup($username);
     }

--- a/src/Service/Rostering/Validation/RosteringUserRowValidator.php
+++ b/src/Service/Rostering/Validation/RosteringUserRowValidator.php
@@ -10,13 +10,13 @@ final class RosteringUserRowValidator
 {
     public const FIELD_USER_USERNAME = 'user_username';
     public const FIELD_USER_PASSWORD = 'user_password';
-    public const FIELD_USER_ORGANIZATION_ID = 'user_organizationId';
+    public const FIELD_HIERARCHY_PARENT_ORGANIZATION_ID = 'hierarchy_parentOrganizationId';
     public const FIELD_SESSION_NAME = 'session_name';
     public const FIELD_USER_ACTIVE = 'user_active';
     public const FIELD_USER_LANGUAGE = 'user_language';
 
     private const MAX_USER_USERNAME_LENGTH = 255;
-    private const MAX_USER_ORGANIZATION_ID_LENGTH = 255;
+    private const MAX_PARENT_ORGANIZATION_ID_LENGTH = 255;
     private const MAX_SESSION_NAME_LENGTH = 255;
 
     public function validateUsername(string $username): void
@@ -44,14 +44,14 @@ final class RosteringUserRowValidator
         }
     }
 
-    public function validateOrganizationId(string $organizationId): void
+    public function validateParentOrganizationId(string $parentOrganizationId): void
     {
-        if (strlen($organizationId) > self::MAX_USER_ORGANIZATION_ID_LENGTH) {
+        if (strlen($parentOrganizationId) > self::MAX_PARENT_ORGANIZATION_ID_LENGTH) {
             throw new RosteringValidationException(
                 sprintf(
                     'Field "%s" exceeds max length (%d).',
-                    self::FIELD_USER_ORGANIZATION_ID,
-                    self::MAX_USER_ORGANIZATION_ID_LENGTH
+                    self::FIELD_HIERARCHY_PARENT_ORGANIZATION_ID,
+                    self::MAX_PARENT_ORGANIZATION_ID_LENGTH
                 )
             );
         }

--- a/tests/Integration/Service/Rostering/RosteringFileProcessorTest.php
+++ b/tests/Integration/Service/Rostering/RosteringFileProcessorTest.php
@@ -83,24 +83,26 @@ class RosteringFileProcessorTest extends AppKernelTestCase
 
         $csv = sprintf(<<<'CSV'
 hierarchy_parentOrganizationId,user_username,user_password,user_organizationId,session_name,user_active,principal_username,marker
-Root,new_user,NewPass1,SCHOOL_1,%s,true,,new_user
-Root,existing_user,ChangedPass1,,%s,1,,pwd_assignment_update
-Root,existing_group_user,,NEW_GROUP,,true,,org_update
+SCHOOL_1,new_user,NewPass1,IGNORED_CLASS,%s,true,,new_user
+PARENT_SCHOOL,parent_group_user,ParentPass1,CHILD_GROUP,%s,true,,parent_group_user
+,existing_user,ChangedPass1,,%s,1,,pwd_assignment_update
+NEW_GROUP,existing_group_user,,IGNORED_CLASS,,true,,org_update
 SCHOOL_1,,,,,,,class_skip
 Root,,,,,,principal_a,principal_skip
-Root,,MissingPass,SCHOOL_2,%s,true,,missing_username
-Root,bad username,Pass1,SCHOOL_3,%s,true,,bad_username
-Root,bad_org,Pass2,BAD ORG,%s,true,,bad_org
-Root,inactive_user,Pass3,SCHOOL_4,%s,false,,inactive
+SCHOOL_2,,MissingPass,IGNORED_CLASS,%s,true,,missing_username
+SCHOOL_3,bad username,Pass1,IGNORED_CLASS,%s,true,,bad_username
+SCHOOL_4,ignored_user_org,Pass2,BAD ORG,%s,true,,ignored_user_org
+SCHOOL_5,inactive_user,Pass3,IGNORED_CLASS,%s,false,,inactive
 Root,inactive_existing_user,,,,false,,inactive_existing
 Root,inactive_existing_user_without_assignment,,,,false,,inactive_existing_without_assignment
-Root,wrong_bool,Pass4,SCHOOL_5,%s,maybe,,invalid_bool
-Root,missing_user_pwd,,SCHOOL_6,%s,true,,missing_user_pwd
-Root,missing_user_org,Pass5,,%s,true,,missing_user_org
-Root,missing_session_name,Pass6,SCHOOL_6,,true,,missing_session_name
-Root,bad_session_name,Pass7,SCHOOL_7,missing-slug,true,,bad_session_name
-Root,existing_user,,,,true,,noop
+SCHOOL_6,wrong_bool,Pass4,IGNORED_CLASS,%s,maybe,,invalid_bool
+SCHOOL_7,missing_user_pwd,,IGNORED_CLASS,%s,true,,missing_user_pwd
+,missing_parent_org,Pass5,IGNORED_CLASS,%s,true,,missing_parent_org
+SCHOOL_8,missing_session_name,Pass6,IGNORED_CLASS,,true,,missing_session_name
+SCHOOL_9,bad_session_name,Pass7,IGNORED_CLASS,missing-slug,true,,bad_session_name
+,existing_user,,,,true,,noop
 CSV,
+            $primaryLineItemSlug,
             $primaryLineItemSlug,
             $secondaryLineItemSlug,
             $primaryLineItemSlug,
@@ -123,6 +125,13 @@ CSV,
         self::assertSame('SCHOOL_1', $newUser->getGroupId());
         self::assertTrue($this->passwordHasher->isPasswordValid($newUser, 'NewPass1'));
         self::assertSame([$primaryLineItemSlug], $this->fetchAssignmentSlugs('new_user'));
+
+        /** @var User|null $parentGroupUserAfter */
+        $parentGroupUserAfter = $this->getRepository(User::class)->findOneBy(['username' => 'parent_group_user']);
+        self::assertInstanceOf(User::class, $parentGroupUserAfter);
+        self::assertSame('PARENT_SCHOOL', $parentGroupUserAfter->getGroupId());
+        self::assertTrue($this->passwordHasher->isPasswordValid($parentGroupUserAfter, 'ParentPass1'));
+        self::assertSame([$primaryLineItemSlug], $this->fetchAssignmentSlugs('parent_group_user'));
 
         /** @var User|null $existingUserAfter */
         $existingUserAfter = $this->getRepository(User::class)->findOneBy(['username' => 'existing_user']);
@@ -178,8 +187,8 @@ CSV,
         self::assertSame('400', $rowsByMarker['bad_username']['status']);
         self::assertSame('validation.fieldError', $rowsByMarker['bad_username']['errorCode']);
 
-        self::assertSame('processed', $rowsByMarker['bad_org']['status']);
-        self::assertSame('', $rowsByMarker['bad_org']['errorCode']);
+        self::assertSame('processed', $rowsByMarker['ignored_user_org']['status']);
+        self::assertSame('', $rowsByMarker['ignored_user_org']['errorCode']);
 
         self::assertSame('400', $rowsByMarker['invalid_bool']['status']);
         self::assertSame('validation.fieldError', $rowsByMarker['invalid_bool']['errorCode']);
@@ -187,8 +196,8 @@ CSV,
         self::assertSame('400', $rowsByMarker['missing_user_pwd']['status']);
         self::assertSame('validation.fieldError', $rowsByMarker['missing_user_pwd']['errorCode']);
 
-        self::assertSame('400', $rowsByMarker['missing_user_org']['status']);
-        self::assertSame('validation.fieldError', $rowsByMarker['missing_user_org']['errorCode']);
+        self::assertSame('400', $rowsByMarker['missing_parent_org']['status']);
+        self::assertSame('validation.fieldError', $rowsByMarker['missing_parent_org']['errorCode']);
 
         self::assertSame('400', $rowsByMarker['missing_session_name']['status']);
         self::assertSame('validation.fieldError', $rowsByMarker['missing_session_name']['errorCode']);
@@ -253,7 +262,7 @@ CSV;
 
         $csv = sprintf(<<<'CSV'
 hierarchy_parentOrganizationId,user_username,user_password,user_organizationId,session_name,user_active,principal_username,marker
-Root,empty_row_case_user_1,Password123,SCHOOL_1,%s,true,,row_1
+SCHOOL_1,empty_row_case_user_1,Password123,IGNORED_CLASS,%s,true,,row_1
 
 ,,,,,,,
 Root,empty_row_case_user_2,Password456,SCHOOL_2,%s,true,,row_2

--- a/tests/Unit/Service/Rostering/Dto/RosteringUserEntryDtoFactoryTest.php
+++ b/tests/Unit/Service/Rostering/Dto/RosteringUserEntryDtoFactoryTest.php
@@ -19,7 +19,7 @@ class RosteringUserEntryDtoFactoryTest extends TestCase
             [
                 RosteringUserRowValidator::FIELD_USER_USERNAME => 'user_1',
                 RosteringUserRowValidator::FIELD_USER_PASSWORD => 'Pass123',
-                RosteringUserRowValidator::FIELD_USER_ORGANIZATION_ID => 'SCHOOL_1',
+                RosteringUserRowValidator::FIELD_HIERARCHY_PARENT_ORGANIZATION_ID => 'COLLEGE_1',
                 RosteringUserRowValidator::FIELD_SESSION_NAME => 'session-1',
                 RosteringUserRowValidator::FIELD_USER_LANGUAGE => 'en',
                 RosteringUserRowValidator::FIELD_USER_ACTIVE => 'true',
@@ -28,7 +28,7 @@ class RosteringUserEntryDtoFactoryTest extends TestCase
 
         $this->assertSame('user_1', $entryDto->getUserUsername());
         $this->assertSame('Pass123', $entryDto->getUserPassword());
-        $this->assertSame('SCHOOL_1', $entryDto->getUserOrganizationId());
+        $this->assertSame('COLLEGE_1', $entryDto->getParentOrganizationId());
         $this->assertSame('session-1', $entryDto->getSessionName());
         $this->assertSame('en', $entryDto->getUserLanguage());
         $this->assertTrue($entryDto->getUserActive());
@@ -60,7 +60,7 @@ class RosteringUserEntryDtoFactoryTest extends TestCase
 
         $subject->fromArray(
             [
-                RosteringUserRowValidator::FIELD_USER_ORGANIZATION_ID => 'SCHOOL_1',
+                RosteringUserRowValidator::FIELD_USER_PASSWORD => 'Pass123',
             ]
         );
     }

--- a/tests/Unit/Service/Rostering/Dto/RosteringUserEntryDtoTest.php
+++ b/tests/Unit/Service/Rostering/Dto/RosteringUserEntryDtoTest.php
@@ -14,7 +14,7 @@ class RosteringUserEntryDtoTest extends TestCase
         $entryDto = new RosteringUserEntryDto(
             'user_1',
             'Pass123',
-            'SCHOOL_1',
+            'COLLEGE_1',
             'session-1',
             'en',
             true
@@ -22,7 +22,7 @@ class RosteringUserEntryDtoTest extends TestCase
 
         $this->assertSame('user_1', $entryDto->getUserUsername());
         $this->assertSame('Pass123', $entryDto->getUserPassword());
-        $this->assertSame('SCHOOL_1', $entryDto->getUserOrganizationId());
+        $this->assertSame('COLLEGE_1', $entryDto->getParentOrganizationId());
         $this->assertSame('session-1', $entryDto->getSessionName());
         $this->assertSame('en', $entryDto->getUserLanguage());
         $this->assertTrue($entryDto->getUserActive());


### PR DESCRIPTION
## Summary

This PR updates SR rostering so user `groupId` is populated from `hierarchy_parentOrganizationId` instead of `user_organizationId`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Rostering CSV imports now require parent organization ID instead of user organization ID for improved user hierarchy management.
  * Parent organization ID is now mandatory when creating new users through roster file import.
  * Enhanced validation for parent organization field values to ensure data quality during imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->